### PR TITLE
Use concrete jq syntax everywhere & HTML output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,37 @@
-COMMON=tour.md syntax.md values.md semantics.md
+COMMON=defs.tex tour.md syntax.md values.md semantics.md
 ICFP=icfp-intro.md $(COMMON) impl.md icfp-concl.md json.md
 SPEC=spec-intro.md $(COMMON) json.md
-DEPS=filter.lua literature.bib template.tex header.tex defs.tex Makefile
+DEPS=filter.lua literature.bib template.tex header.tex Makefile
 
 PANOPTS= \
   --from=markdown+tex_math_single_backslash+tex_math_dollars+raw_tex \
-  --to=latex \
   --lua-filter filter.lua \
-  --bibliography=literature.bib --natbib \
-  --template template.tex \
-  --include-in-header header.tex \
-  --include-in-header defs.tex \
+  --bibliography=literature.bib \
   --standalone \
   --columns 10000 # TODO!
 
-all: icfp.pdf spec.pdf
+LATEXOPTS=$(PANOPTS) --natbib --template template.tex --include-in-header header.tex
+HTMLOPTS=$(PANOPTS) --citeproc --mathjax
+
+
+all: icfp.pdf spec.pdf spec.html
 clean:
 	rm *.aux *.bbl *.blg *.log *.pdf structure.tex icfp.tex spec.tex
 
 icfp.tex: icfp.yaml $(ICFP) $(DEPS) structure.tex ccs.tex
-	pandoc --metadata-file $< $(ICFP) $(PANOPTS) -o $@ -H ccs.tex
+	pandoc --metadata-file $< $(ICFP) $(LATEXOPTS) -o $@ -H ccs.tex
 
 spec.tex: spec.yaml $(SPEC) $(DEPS)
-	pandoc --metadata-file $< $(SPEC) $(PANOPTS) -o $@
+	pandoc --metadata-file $< $(SPEC) $(LATEXOPTS) -o $@
+
+spec.html: spec.yaml $(SPEC) $(DEPS)
+	pandoc --metadata-file $< $(SPEC) $(HTMLOPTS) -o $@
 
 %.pdf: %.tex
 	xelatex $<
 	bibtex $*
 	xelatex $<
 	xelatex $<
-
-html:
-	pandoc $(FILENAME).md \
-	--lua-filter filter.lua \
-	--citeproc \
-	--from=markdown+tex_math_single_backslash+tex_math_dollars+markdown_in_html_blocks \
-	--to=html5 \
-	--output=$(FILENAME).html \
-	--mathjax \
-	#--standalone
 
 # remove trailing semicolons to suppress error messages
 structure.tex: structure.dot

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ a formal specification of the programming language provided by [`jq`].
 A rendered version is available [here](https://github.com/01mf02/jq-lang-spec/releases/latest/download/spec.pdf).
 
 Run `make spec.pdf` to generate a PDF version of the specification.
-For this, Pandoc and a TeX distribution should be installed.
+For this, `pandoc`, `dot2tex`, and a TeX distribution should be installed.
+(I currently use `pandoc` 3.4 and `dot2tex` 2.11.3.)
 
 [`jq`]: https://jqlang.github.io/jq/

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ Run `make spec.pdf` to generate a PDF version of the specification.
 For this, `pandoc`, `dot2tex`, and a TeX distribution should be installed.
 (I currently use `pandoc` 3.4 and `dot2tex` 2.11.3.)
 
+For interactive regeneration: `ls | entr make spec.pdf`
+
 [`jq`]: https://jqlang.github.io/jq/

--- a/defs.tex
+++ b/defs.tex
@@ -1,10 +1,9 @@
-% https://tex.stackexchange.com/questions/742495/spacing-before-and-after-text-operators
+<!-- https://tex.stackexchange.com/questions/742495/spacing-before-and-after-text-operators -->
 \newcommand{\rsep}{\mathclose{}}
 
-% jq syntax
+<!-- jq syntax -->
 \newcommand{\jqf }[1]{\mathtt{#1}}
 \newcommand{\jqkw}[1]{\mathrel{\jqf{#1}}}
-\newcommand{\jqop}[1]{\mathrel{\normalfont{\texttt{#1}}}}
 \newcommand{\jqas}{\jqkw{as}}
 \newcommand{\jqdef }[2]{\jqkw{def} #1\!: #2;\;}
 \newcommand{\jqite }[3]{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
@@ -52,7 +51,7 @@
 \newcommand{\bindr}{\bind_R}
 \newcommand{\bindl}{\bind_L}
 
-% types
+<!-- types -->
 \newcommand{\boolt}{\mathbb{B}}
 \newcommand{\valt}{\mathcal{V}}
 \newcommand{\listt}{\mathcal{L}}

--- a/defs.tex
+++ b/defs.tex
@@ -1,16 +1,25 @@
-% When a \mathrel such as `=` or `:=` is followed by another \mathrel,
-% no space is inserted between the two.
-% This is very unfortunate.
-% To work around this, we can put \mathop{} before the \mathrel.
-% According to TeX by topic (§23.6.1),
-% when we have `\mathrel{a} \mathop{} \mathrel{b}`,
-% a \thickmuskip is inserted before and after \mathop{}, and
-% when we have `\mathop{} \mathrel{b}` (no \mathrel{...} before \mathop{}),
-% a \thickmuskip is inserted after \mathop{}.
-% We remove the superfluous \thickmuskip to get the desired spacing.
-\newcommand{\relrel}{\mathop{}\mskip-\thickmuskip}
-
 % https://tex.stackexchange.com/questions/742495/spacing-before-and-after-text-operators
+\newcommand{\rsep}{\mathclose{}}
+
+% jq macros
+\newcommand{\jqf }[1]{\mathtt{#1}}
+\newcommand{\jqkw}[1]{\mathrel{\jqf{#1}}}
+\newcommand{\jqas}{\jqkw{as}}
+\newcommand{\jqdef }[3]{\jqkw{def} #1\!: #2;\; #3}
+\newcommand{\jqite }[3]{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
+\newcommand{\jqfold}[4]{\jqkw{#1} #2 \jqas #3\; #4}
+\newcommand{\jqlb  }[2]{\jqkw{#1}\, \$#2}
+
+% IR macros
+\newcommand{\irf }[1]{\mathrm{#1}}
+\newcommand{\irkw}[1]{\mathrel{\irf{#1}}}
+\newcommand{\iras}{\irkw{as}}
+\newcommand{\irdef }[3]{\irkw{def} #1\!: #2;\; #3}
+\newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3}
+\newcommand{\irfold}[4]{\irkw{#1} #2 \iras #3\; #4}
+\newcommand{\irlb  }[2]{\irkw{#1}\, \$#2}
+\newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
+
 \newcommand{\relname}[1]{\mathrel{\mathrm{#1}}}
 
 \newcommand{\reduce}{\relname{reduce}}
@@ -24,7 +33,7 @@
 \newcommand{\catch}{\relname{catch}}
 \newcommand{\deff}{\relname{def}}
 \newcommand{\ite}[3]{{\relname{if} #1 \relname{then} #2 \relname{else} #3}}
-\newcommand{\gror}{\quad\|\quad}
+\newcommand{\gror}{\mathbin{\quad\|\quad}}
 \newcommand{\cartesian}{\mathrel{\circ}}
 \newcommand{\labelx}[1]{{\labelf\,\$#1}}
 \newcommand{\breakx}[1]{{\breakf\,\$#1}}
@@ -38,10 +47,9 @@
 \newcommand{\floor}[1]{\lfloor#1\rfloor}
 \newcommand{\ceil}[1]{\lceil#1\rceil}
 \newcommand{\bool}{\operatorname{bool}}
-\newcommand{\true}{\operatorname{true}}
-\newcommand{\false}{\operatorname{false}}
+\newcommand{\true}{\irf{true}}
+\newcommand{\false}{\irf{false}}
 \newcommand{\length}{\operatorname{length}}
-\newcommand{\wf}{\operatorname{wf}}
 \newcommand{\recurse}{\operatorname{recurse}}
 \newcommand{\repeatf}{\operatorname{repeat}}
 \newcommand{\emptyf}{\operatorname{empty}}

--- a/defs.tex
+++ b/defs.tex
@@ -39,9 +39,7 @@
 \newcommand{\breakx}[1]{{\breakf\,\$#1}}
 \newcommand{\update}{\mathbin{|{=}}}
 \newcommand{\alt}{\mathbin{/\!/}}
-\newcommand{\alteq}{\mathbin{\alt{=}}}
 \newcommand{\arith}{\odot}
-\newcommand{\aritheq}{\mathbin{\arith{=}}}
 \newcommand{\fold}{\phi}
 \newcommand{\foldf}{\operatorname{fold}}
 \newcommand{\floor}[1]{\lfloor#1\rfloor}
@@ -50,7 +48,6 @@
 \newcommand{\true}{\irf{true}}
 \newcommand{\false}{\irf{false}}
 \newcommand{\length}{\operatorname{length}}
-\newcommand{\recurse}{\operatorname{recurse}}
 \newcommand{\repeatf}{\operatorname{repeat}}
 \newcommand{\emptyf}{\operatorname{empty}}
 \newcommand{\stream}[1]{\langle#1\rangle}

--- a/defs.tex
+++ b/defs.tex
@@ -1,5 +1,18 @@
+% When a \mathrel such as `=` or `:=` is followed by another \mathrel,
+% no space is inserted between the two.
+% This is very unfortunate.
+% To work around this, we can put \mathop{} before the \mathrel.
+% According to TeX by topic (§23.6.1),
+% when we have `\mathrel{a} \mathop{} \mathrel{b}`,
+% a \thickmuskip is inserted before and after \mathop{}, and
+% when we have `\mathop{} \mathrel{b}` (no \mathrel{...} before \mathop{}),
+% a \thickmuskip is inserted after \mathop{}.
+% We remove the superfluous \thickmuskip to get the desired spacing.
+\newcommand{\relrel}{\mathop{}\mskip-\thickmuskip}
+
 % https://tex.stackexchange.com/questions/742495/spacing-before-and-after-text-operators
-\newcommand{\relname}[1]{\mathrel{\operatorname{#1}}}
+\newcommand{\relname}[1]{\mathrel{\mathrm{#1}}}
+
 \newcommand{\reduce}{\relname{reduce}}
 \newcommand{\foreac}{\relname{foreach}}
 \newcommand{\labelf}{\relname{label}}

--- a/defs.tex
+++ b/defs.tex
@@ -5,7 +5,7 @@
 \newcommand{\jqf }[1]{\mathtt{#1}}
 \newcommand{\jqkw}[1]{\mathrel{\jqf{#1}}}
 \newcommand{\jqas}{\jqkw{as}}
-\newcommand{\jqdef }[3]{\jqkw{def} #1\!: #2;\; #3}
+\newcommand{\jqdef }[2]{\jqkw{def} #1\!: #2;\;}
 \newcommand{\jqite }[3]{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
 \newcommand{\jqfold}[4]{\jqkw{#1} #2 \jqas #3\; #4}
 \newcommand{\jqlb  }[2]{\jqkw{#1}\, \$#2}
@@ -14,42 +14,24 @@
 \newcommand{\irf }[1]{\mathrm{#1}}
 \newcommand{\irkw}[1]{\mathrel{\irf{#1}}}
 \newcommand{\iras}{\irkw{as}}
-\newcommand{\irdef }[3]{\irkw{def} #1\!: #2;\; #3}
+\newcommand{\irdef }[2]{\irkw{def} #1\!: #2;\;}
 \newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3}
 \newcommand{\irfold}[4]{\irkw{#1} #2 \iras #3\; #4}
 \newcommand{\irlb  }[2]{\irkw{#1}\, \$#2}
 \newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
 
-\newcommand{\relname}[1]{\mathrel{\mathrm{#1}}}
-
-\newcommand{\reduce}{\relname{reduce}}
-\newcommand{\foreac}{\relname{foreach}}
-\newcommand{\labelf}{\relname{label}}
-\newcommand{\breakf}{\relname{break}}
-\newcommand{\as}{\relname{as}}
-\newcommand{\andop}{\relname{and}}
-\newcommand{\orop}{\relname{or}}
-\newcommand{\try}{\relname{try}}
-\newcommand{\catch}{\relname{catch}}
-\newcommand{\deff}{\relname{def}}
-\newcommand{\ite}[3]{{\relname{if} #1 \relname{then} #2 \relname{else} #3}}
 \newcommand{\gror}{\mathbin{\quad\|\quad}}
 \newcommand{\cartesian}{\mathrel{\circ}}
-\newcommand{\labelx}[1]{{\labelf\,\$#1}}
-\newcommand{\breakx}[1]{{\breakf\,\$#1}}
 \newcommand{\update}{\mathbin{|{=}}}
 \newcommand{\alt}{\mathbin{/\!/}}
 \newcommand{\arith}{\odot}
 \newcommand{\fold}{\phi}
-\newcommand{\foldf}{\operatorname{fold}}
 \newcommand{\floor}[1]{\lfloor#1\rfloor}
 \newcommand{\ceil}[1]{\lceil#1\rceil}
 \newcommand{\bool}{\operatorname{bool}}
 \newcommand{\true}{\irf{true}}
 \newcommand{\false}{\irf{false}}
 \newcommand{\length}{\operatorname{length}}
-\newcommand{\repeatf}{\operatorname{repeat}}
-\newcommand{\emptyf}{\operatorname{empty}}
 \newcommand{\stream}[1]{\langle#1\rangle}
 \newcommand{\obj}[1]{\left\{#1\right\}}
 \newcommand{\eval}{\operatorname{eval}}
@@ -59,7 +41,7 @@
 \newcommand{\upd}{\operatorname{upd}}
 \newcommand{\ok}{\operatorname{ok}}
 \newcommand{\err}{\operatorname{err}}
-\newcommand{\error}{\operatorname{error}}
+\newcommand{\breakf}{\operatorname{break}}
 \newcommand{\zero}{\operatorname{zero}}
 \newcommand{\succf}{\operatorname{succ}}
 \newcommand{\nateq}{\operatorname{nat\_eq}}
@@ -72,8 +54,6 @@
 \newcommand{\trues}{\operatorname{trues}}
 \newcommand{\dom}{\operatorname{dom}}
 \newcommand{\keys}{\operatorname{keys}}
-\newcommand{\first}{\operatorname{first}}
-\newcommand{\last}{\operatorname{last}}
 \newcommand{\bind}{\mathop{>\!\!\!>\!=}\nolimits}
 \newcommand{\bindr}{\bind_R}
 \newcommand{\bindl}{\bind_L}

--- a/defs.tex
+++ b/defs.tex
@@ -1,25 +1,25 @@
 % https://tex.stackexchange.com/questions/742495/spacing-before-and-after-text-operators
 \newcommand{\rsep}{\mathclose{}}
 
-% jq macros
+% jq syntax
 \newcommand{\jqf }[1]{\mathtt{#1}}
 \newcommand{\jqkw}[1]{\mathrel{\jqf{#1}}}
+\newcommand{\jqop}[1]{\mathrel{\normalfont{\texttt{#1}}}}
 \newcommand{\jqas}{\jqkw{as}}
 \newcommand{\jqdef }[2]{\jqkw{def} #1\!: #2;\;}
 \newcommand{\jqite }[3]{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
 \newcommand{\jqfold}[4]{\jqkw{#1} #2 \jqas #3\; #4}
 \newcommand{\jqlb  }[2]{\jqkw{#1}\, \$#2}
+\newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
 
 % IR macros
 \newcommand{\irf }[1]{\mathtt{#1}}
 \newcommand{\irkw}[1]{\mathrel{\irf{#1}}}
-\newcommand{\irop}[1]{\mathrel{\normalfont{\texttt{#1}}}}
 \newcommand{\iras}{\irkw{as}}
 \newcommand{\irdef }[2]{\irkw{def} #1\!: #2;\;}
 \newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3 \irkw{end}}
 \newcommand{\irfold}[4]{\irkw{#1} #2 \iras #3\; #4}
 \newcommand{\irlb  }[2]{\irkw{#1}\, \$#2}
-\newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
 
 \newcommand{\gror}{\mathbin{\quad\|\quad}}
 \newcommand{\cartesian}{\mathrel{\circ}}

--- a/defs.tex
+++ b/defs.tex
@@ -11,11 +11,12 @@
 \newcommand{\jqlb  }[2]{\jqkw{#1}\, \$#2}
 
 % IR macros
-\newcommand{\irf }[1]{\mathrm{#1}}
+\newcommand{\irf }[1]{\mathtt{#1}}
 \newcommand{\irkw}[1]{\mathrel{\irf{#1}}}
+\newcommand{\irop}[1]{\mathrel{\normalfont{\texttt{#1}}}}
 \newcommand{\iras}{\irkw{as}}
 \newcommand{\irdef }[2]{\irkw{def} #1\!: #2;\;}
-\newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3}
+\newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3 \irkw{end}}
 \newcommand{\irfold}[4]{\irkw{#1} #2 \iras #3\; #4}
 \newcommand{\irlb  }[2]{\irkw{#1}\, \$#2}
 \newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
@@ -30,8 +31,8 @@
 \newcommand{\floor}[1]{\lfloor#1\rfloor}
 \newcommand{\ceil}[1]{\lceil#1\rceil}
 \newcommand{\bool}{\operatorname{bool}}
-\newcommand{\true}{\irf{true}}
-\newcommand{\false}{\irf{false}}
+\newcommand{\true}{\operatorname{true}}
+\newcommand{\false}{\operatorname{false}}
 \newcommand{\length}{\operatorname{length}}
 \newcommand{\stream}[1]{\langle#1\rangle}
 \newcommand{\obj}[1]{\left\{#1\right\}}

--- a/defs.tex
+++ b/defs.tex
@@ -24,6 +24,7 @@
 \newcommand{\cartesian}{\mathrel{\circ}}
 \newcommand{\update}{\mathbin{|{=}}}
 \newcommand{\alt}{\mathbin{/\!/}}
+\newcommand{\iseq}{\stackrel{?}{=}}
 \newcommand{\arith}{\odot}
 \newcommand{\fold}{\phi}
 \newcommand{\floor}[1]{\lfloor#1\rfloor}

--- a/defs.tex
+++ b/defs.tex
@@ -10,22 +10,14 @@
 \newcommand{\jqite }[3]{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
 \newcommand{\jqfold}[4]{\jqkw{#1} #2 \jqas #3\; #4}
 \newcommand{\jqlb  }[2]{\jqkw{#1}\, \$#2}
-\newcommand{\irtc  }[2]{\irkw{try} #1 \irkw{catch} #2}
-
-% IR macros
-\newcommand{\irf }[1]{\mathtt{#1}}
-\newcommand{\irkw}[1]{\mathrel{\irf{#1}}}
-\newcommand{\iras}{\irkw{as}}
-\newcommand{\irdef }[2]{\irkw{def} #1\!: #2;\;}
-\newcommand{\irite }[3]{\irkw{if} #1 \irkw{then} #2 \irkw{else} #3 \irkw{end}}
-\newcommand{\irfold}[4]{\irkw{#1} #2 \iras #3\; #4}
-\newcommand{\irlb  }[2]{\irkw{#1}\, \$#2}
+\newcommand{\jqtc  }[2]{\jqkw{try} #1 \jqkw{catch} #2}
 
 \newcommand{\gror}{\mathbin{\quad\|\quad}}
 \newcommand{\cartesian}{\mathrel{\circ}}
 \newcommand{\update}{\mathbin{|{=}}}
 \newcommand{\alt}{\mathbin{/\!/}}
 \newcommand{\iseq}{\stackrel{?}{=}}
+\newcommand{\modulo}{\mathbin{\%}}
 \newcommand{\arith}{\odot}
 \newcommand{\fold}{\phi}
 \newcommand{\floor}[1]{\lfloor#1\rfloor}
@@ -60,8 +52,7 @@
 \newcommand{\bindr}{\bind_R}
 \newcommand{\bindl}{\bind_L}
 
-\newcommand{\modulo}{\mathbin{\%}}
-
+% types
 \newcommand{\boolt}{\mathbb{B}}
 \newcommand{\valt}{\mathcal{V}}
 \newcommand{\listt}{\mathcal{L}}

--- a/icfp-concl.md
+++ b/icfp-concl.md
@@ -3,13 +3,11 @@
 We have shown formal syntax and semantics of
 a large subset of the jq programming language.
 
-On the syntax side, we first defined
-formal syntax (HIR) that closely corresponds to actual jq syntax.
-We then gave a lowering that reduces HIR to a simpler subset (MIR),
-in order to simplify the semantics later.
-We finally showed how a subset of actual jq syntax can be translated into HIR and thus MIR.
+On the syntax side, we first defined a subset of jq's filter syntax.
+We then introduced a simpler subset (IR) in order to simplify the semantics later,
+and gave a lowering from concrete jq syntax to IR.
 
-On the semantics side, we gave formal semantics based on MIR.
+On the semantics side, we gave formal semantics based on IR.
 First, we defined values and basic operations on them.
 Then, we used this to define the semantics of jq programs,
 by specifying how to compile a jq program to a lambda term.

--- a/icfp-intro.md
+++ b/icfp-intro.md
@@ -72,8 +72,7 @@ give a glimpse of actual jq syntax and behaviour.
 From that point on, the structure of the text follows
 the execution of a jq program as shown in @fig:structure.
 @sec:syntax formalises a subset of jq syntax and shows how jq syntax can be
-transformed to increasingly low-level intermediate representations called
-HIR (@sec:hir) and MIR (@sec:mir).
+transformed to a more low-level intermediate representation called IR (@sec:mir).
 After this, the semantics part starts:
 @sec:values defines several data types and corresponding lambda terms, such as
 values, value results, and lists.

--- a/json.md
+++ b/json.md
@@ -6,7 +6,7 @@ In this section, we will define JSON values.
 Furthermore, we will define several functions and operations on values.
 
 A JSON value $v$ has the shape
-$$v \coloneq \nullf \gror \false \gror \true \gror n \gror s \gror [v_0, ..., v_n] \gror \obj{k_0 \mapsto v_0, ..., k_n \mapsto v_n},$$
+$$v \coloneqq \nullf \gror \false \gror \true \gror n \gror s \gror [v_0, ..., v_n] \gror \obj{k_0 \mapsto v_0, ..., k_n \mapsto v_n},$$
 where $n$ is a number and $s$ is a string.
 We write a string $s$ as $c_0...c_n$, where $c$ is a character.
 A value of the shape $[v_0, ..., v_n]$ is called an _array_ and
@@ -57,10 +57,10 @@ supports the arithmetic operations $+$, $-$, $\times$, $\div$, and $\modulo$ (mo
 
 In this subsection, we will introduce functions to construct arrays and objects.
 \begin{alignat*}{3}
-\arr _0:{}&             &&            && \valt \coloneq [] \\
-\arr _1:{}&             &&\valt \to{} && \valt \coloneq \lambda v. [v] \\
-\objf_0:{}&             &&            && \valt \coloneq \obj{} \\
-\objf_1:{}& \valt \to{} &&\valt \to{} && \resultt \coloneq \lambda k\, v. \begin{cases}
+\arr _0:{}&             &&            && \valt \coloneqq [] \\
+\arr _1:{}&             &&\valt \to{} && \valt \coloneqq \lambda v. [v] \\
+\objf_0:{}&             &&            && \valt \coloneqq \obj{} \\
+\objf_1:{}& \valt \to{} &&\valt \to{} && \resultt \coloneqq \lambda k\, v. \begin{cases}
   \ok \obj{k \mapsto v} & \text{if $k$ is a string} \\
   \err ... & \text{otherwise}
 \end{cases}
@@ -74,7 +74,7 @@ $\arr$ defined in @sec:value-ops based on $\arr_0$ and $\arr_1$.
 We are now going to define several functions on values.
 
 The _keys_ of a value are defined as follows:
-$$\keys: \valt \to \listt \coloneq \lambda v. \begin{cases}
+$$\keys: \valt \to \listt \coloneqq \lambda v. \begin{cases}
   \stream{\ok 0, ...,   \ok n} & \text{if } v = [v_0, ..., v_n] \\
   \stream{\ok{k_0}} + \keys\, v' & \text{if } v = \obj{k_0 \mapsto v_0} \cup v' \text{ and } k_0 = \min(\dom(v)) \\
   \stream{} & \text{if } v = {} \\
@@ -85,7 +85,7 @@ the domain of the object sorted by ascending order.
 For the used ordering, see @sec:json-order.
 
 We define the _length_ of a value as follows:
-$$\length: \valt \to \resultt \coloneq \lambda v. \begin{cases}
+$$\length: \valt \to \resultt \coloneqq \lambda v. \begin{cases}
   \ok 0    & \text{if } v = \nullf \\
   \ok |n|  & \text{if $v$ is a number $n$} \\
   \ok n    & \text{if } v = c_1...c_n \\
@@ -102,7 +102,7 @@ $|a|$ is the length of an array $a$, and
 $|o|$ is the cardinality of the domain of an object $o$.
 
 The _boolean value_ of a value $v$ is defined as follows:
-$$\bool: \valt \to \boolt \coloneq \lambda v. \begin{cases}
+$$\bool: \valt \to \boolt \coloneqq \lambda v. \begin{cases}
   \false & \text{if $v = \nullf$ or $v = \false$} \\
   \true & \text{otherwise}
 \end{cases}$$
@@ -135,7 +135,7 @@ respectively.
 ### Addition
 
 We define addition of two values $l$ and $r$ as follows:
-$$l + r \coloneq \begin{cases}
+$$l + r \coloneqq \begin{cases}
   \ok v & \text{if $l = \nullf$ and $r = v$, or $l = v$ and $r = \nullf$} \\
   \ok (n_1 + n_2) & \text{if $l$ is a number $n_1$ and $r$ is a number $n_2$} \\
   \ok (c_{l,1}...c_{l,m}c_{r,1}...c_{r,n}) & \text{if $l = c_{l,1}...c_{l,m}$ and $r = c_{r,1}...c_{r,n}$} \\
@@ -150,7 +150,7 @@ for objects, it corresponds to their union.
 ### Multiplication
 
 Given two objects $l$ and $r$, we define their _recursive merge_ $l \Cup r$ as:
-$$l \Cup r \coloneq \begin{cases}
+$$l \Cup r \coloneqq \begin{cases}
   {k \mapsto v_l \Cup v_r} \cup l' \Cup r' & \text{if $l = \obj{k \mapsto v_l} \cup l'$, $r = \obj{k \mapsto v_r} \cup r'$, and $v_l, v_r$ are objects} \\
   \obj{k \mapsto v_r} \cup l' \Cup r' & \text{if $l = {k \mapsto v_l} \cup l'$, $r = \obj{k \mapsto v_r} \cup r'$, and $v_l$ or $v_r$ is not an object} \\
   \obj{k \mapsto v_r} \cup l \Cup r' & \text{if $k \notin \dom(l)$ and $r = \obj{k \mapsto v_r} \cup r'$} \\
@@ -158,7 +158,7 @@ $$l \Cup r \coloneq \begin{cases}
 \end{cases}$$
 
 We use $\Cup$ in the following definition of multiplication of two values $l$ and $r$:
-$$l \times r \coloneq \begin{cases}
+$$l \times r \coloneqq \begin{cases}
   \ok(n_1 \times n_2) & \text{if $l$ is a number $n_1$ and $r$ is a number $n_2$} \\
   \sum_{i = 1}^n s & \text{if $l$ is a string $s$ and $r$ is a number $n \in \mathbb Z$} \\
   r \times l & \text{if $r$ is a string and $l \in \mathbb Z$} \\
@@ -174,7 +174,7 @@ The multiplication of two objects corresponds to their recursive merge as define
 ### Subtraction
 
 We now define subtraction of two values $l$ and $r$:
-$$l - r \coloneq \begin{cases}
+$$l - r \coloneqq \begin{cases}
   \ok(n_1 - n_2) & \text{if $l$ is a number $n_1$ and $r$ is a number $n_2$} \\
   \arr (\sum_{i, l_i \notin \{r_0, ..., r_n\}} \stream{\ok l_i}) & \text{if $l = [l_0, ..., l_n]$ and $r = [r_0, ..., r_n]$} \\
   \err ... & \text{otherwise}
@@ -188,7 +188,7 @@ an array containing those values of $l$ that are not contained in $r$.
 We will now define a function that
 splits a string $y + x$ by some non-empty separator string $s$.
 The function preserves the invariant that $y$ does not contain $s$:
-$$\splitf \coloneq \lambda x\, s\, y. \begin{cases}
+$$\splitf \coloneqq \lambda x\, s\, y. \begin{cases}
   \splitf\, (c_1...c_n)\, s\, (y + c_0) & \text{if $x = c_0...c_n$ and $c_0...c_{|s| - 1} \neq s$} \\
   [y] + \splitf\, (c_{|s|}...c_n)\, s\, "" & \text{if $x = c_0...c_n$ and $c_0...c_{|s| - 1} = s$} \\
   [y] & \text{otherwise ($|x| = 0$)}
@@ -196,7 +196,7 @@ $$\splitf \coloneq \lambda x\, s\, y. \begin{cases}
 
 We use this splitting function to define division of two values:
 
-$$l \div r \coloneq \begin{cases}
+$$l \div r \coloneqq \begin{cases}
   \ok(n_1 \div n_2) & \text{if $l$ is a number $n_1$ and $r$ is a number $n_2$} \\
   \ok [] & \text{if $l$ and $r$ are strings and $|l| = 0$} \\
   \arr (\sum_i \stream{\ok c_i}) & \text{if $l = c_0...c_n$, $r$ is a string, $|l| > 0$, and $|r| = 0$} \\
@@ -238,7 +238,7 @@ These serve to extract values that are contained within other values.
 
 The value $v[i]$ of a value $v$ at index $i$ is defined as follows:
 
-$$v[i] \coloneq \begin{cases}
+$$v[i] \coloneqq \begin{cases}
   \ok v_i    & \text{if $v = [v_0, ..., v_n]$, $i \in \mathbb N$, and $i \leq n$} \\
   \ok \nullf & \text{if $v = [v_0, ..., v_n]$, $i \in \mathbb N$, and $i > n$} \\
   v[n+i]     & \text{if $v = [v_0, ..., v_n]$, $i \in \mathbb Z \setminus \mathbb N$, and $0 \leq n+i$} \\
@@ -261,7 +261,7 @@ The behaviour of this operator for $i < 0$ is that $v[i]$ equals $v[|v| + i]$.
 :::
 
 Using the index operator, we can define the values $v[]$ in a value $v$ as follows:
-$$v[] \coloneq \keys v \bind \lambda k. \stream{v[k]}$$
+$$v[] \coloneqq \keys v \bind \lambda k. \stream{v[k]}$$
 When provided with
 an array $v = [v_0, ..., v_n]$ or
 an object $v = \obj{k_0 \mapsto v_0, ..., k_n \mapsto v_n}$
@@ -269,7 +269,7 @@ an object $v = \obj{k_0 \mapsto v_0, ..., k_n \mapsto v_n}$
 $v[]$ returns the stream $\stream{\ok v_0, ..., \ok v_n}$.
 
 Next, we define a slice operator:
-$$v[i:j] \coloneq \begin{cases}
+$$v[i:j] \coloneqq \begin{cases}
   \ok [v_i, ..., v_{j-1}] & \text{if $v = [v_0, ..., v_n]$ and $i, j \in \mathbb N$} \\
   \ok (c_i  ...  c_{j-1}) & \text{if $v =  c_0  ...  c_n $ and $i, j \in \mathbb N$} \\
   v[(n+i):j] & \text{if $|v| = n$, $i \in \mathbb Z \setminus \mathbb N$, and $0 \leq n+i$} \\
@@ -290,13 +290,13 @@ an empty string if $v$ is a string.
 $v[]$ fulfills this, whereas $v[i]$ and $v[i:j]$ return a single value result.
 For that reason, we now redefine these operators to return a stream of value results, by
 \begin{align*}
-v[i]   &\coloneq \stream{v[i]} \\
-v[i:j] &\coloneq \stream{v[i:j]}
+v[i]   &\coloneqq \stream{v[i]} \\
+v[i:j] &\coloneqq \stream{v[i:j]}
 \end{align*}
 Finally, we define the remaining access operators by using the slice operator:
 \begin{alignat*}{4}
-v[:j] &\coloneq                                       && v[0 &&: &j&] \\
-v[i:] &\coloneq \stream{\length\, v} \bind \lambda l. && v[i &&: &l&]
+v[:j] &\coloneqq                                       && v[0 &&: &j&] \\
+v[i:] &\coloneqq \stream{\length\, v} \bind \lambda l. && v[i &&: &l&]
 \end{alignat*}
 
 When $\length\, v$ yields an error, then $v[i:]$ yields an error, too.
@@ -318,7 +318,7 @@ a value $v: \valt$ and a function $f: \valt \to \listt$, and return a value resu
 The first update operator will be a counterpart to $v[]$.
 For all elements $x$ that are yielded by $v[]$,
 $v[] \update f$ replaces $x$ by $f(x)$:
-$$v[] \update f \coloneq \begin{cases}
+$$v[] \update f \coloneqq \begin{cases}
   \arr (\sum_i f(v_i)) & \text{if } v = [v_0, ..., v_n] \\
   \sumf\, (\keys v \bind \lambda k. v[k] \bind \lambda v. \stream{\objif\, k\, (f\, v)})\, \obj{} & \text{if $v$ is an object} \\
   \err ... & \text{otherwise}
@@ -327,7 +327,7 @@ $$v[] \update f \coloneq \begin{cases}
 Here, we use the function $\sumf$ from @sec:value-ops as well as
 a helper function for the case that $v$ is an object.
 This function takes an object key $k$ and $s: \listt$ and returns a value result:
-$$\objif \coloneq \lambda k\, s. s\, (\lambda h\, t. h \bindr \lambda o. \ok \obj{k \mapsto o})\, (\ok \obj{})$$
+$$\objif \coloneqq \lambda k\, s. s\, (\lambda h\, t. h \bindr \lambda o. \ok \obj{k \mapsto o})\, (\ok \obj{})$$
 
 For an input array $v = [v_0, ..., v_n]$,
 $v[] \update f$ replaces each $v_i$ by the output of $f(v_i)$, yielding
@@ -342,10 +342,10 @@ jq only considers the first value yielded by $f$.
 For the next operators, we will use the following function
 $\cut\, v\, i\, j\, n\, s$, which
 replaces the slice $[i:j]$ of an array $v$ of length $n$ by a stream $s$:
-$$\cut \coloneq \lambda v\, i\, j\, n\, s. \sumf\, (v[0:i] + s + v[j:n])\, []$$
+$$\cut \coloneqq \lambda v\, i\, j\, n\, s. \sumf\, (v[0:i] + s + v[j:n])\, []$$
 
 The next operator replaces the $i$-th element of a value $v$ by the outputs of $f$:
-$$v[i] \update f \coloneq \begin{cases}
+$$v[i] \update f \coloneqq \begin{cases}
   \cut\, v\, i\, (i+1)\, n\, \stream{\arr (f v_i)} & \text{if $v = [v_0, ..., v_n]$, $i \in \mathbb N$, and $i \leq n$} \\
   v[n+i] \update f & \text{if $v = [v_0, ..., v_n]$, $i \in \mathbb Z \setminus \mathbb N$, and $0 \leq n+i$} \\
   \objif\, i\, (f\, v') \bindr \lambda y. y + o & \text{if } v = \obj{i \mapsto v'} \cup o \\
@@ -361,7 +361,7 @@ we cannot provide a default element e that would make the key disappear
 
 The final operator is the update counterpart of the operator $v[i:j]$.
 It replaces the slice $v[i:j]$ by the concatenation of the outputs of $f$ on $v[i:j]$.
-$$v[i:j] \update f \coloneq \begin{cases}
+$$v[i:j] \update f \coloneqq \begin{cases}
   \cut\, v\, i\, j\, n\, (v[i:j] >>= f) & \text{if $v = [v_0, ..., v_n],$ $i, j \in \mathbb N$, and $i \leq j$} \\
   \ok v & \text{if $v = [v_0, ..., v_n]$, $i, j \in \mathbb N$, and $i > j$} \\
   v[(n+i):j] \update f & \text{if $|v| = n$, $i \in \mathbb Z \setminus \mathbb N$, and $0 \leq n+i$} \\
@@ -382,8 +382,8 @@ $f$ returns multiple values, in which case jq considers only the first output of
 
 Similarly to @sec:json-access, we define the remaining operators by $v[i:j]$:
 \begin{alignat*}{3}
-v[:j] \update f &\coloneq                             && v[0:&j] \update f \\
-v[i:] \update f &\coloneq \length v \bindr \lambda l. && v[i:&l] \update f
+v[:j] \update f &\coloneqq                             && v[0:&j] \update f \\
+v[i:] \update f &\coloneqq \length v \bindr \lambda l. && v[i:&l] \update f
 \end{alignat*}
 
 

--- a/semantics.md
+++ b/semantics.md
@@ -40,7 +40,7 @@ $t_u = \sigma\, v$ was obtained from @tab:update-semantics.
 The lambda term $\sem \varphi$ obtained from a well-formed filter $\varphi$
 may contain at most one free variable, namely $\fresh$.
 This variable is used to generate fresh labels for the execution of
-$\irlb{label}{x} | f$, see @ex:labels.
+$\jqlb{label}{x} | f$, see @ex:labels.
 In order to create a closed term, we initially bind $\fresh$ to zero.
 We can then run a filter using the following function:
 $$\eval: \filtert \to \valt \to \listt \coloneq \lambda \varphi. (\lambda \fresh. \run\, \varphi)\, \zero$$
@@ -65,15 +65,15 @@ Table: Evaluation semantics. {#tab:eval-semantics}
 | $f, g$ | $\run\, \sem f\, v + \run\, \sem g\, v$ |
 | $f | g$ | $\run\, \sem f\, v \bind \run\, \sem g$ |
 | $f \alt g$ | $(\lambda t. t\, (\lambda \_\, \_. t)\, (\run\, \sem g\, v))\, (\run\, \sem f\, v \bind \trues)$ |
-| $f \iras \$x | g$ | $\run\, \sem f\, v \bind (\lambda \$x. \run, \sem g\, v)$ |
-| $\irtc{f}{g}$ | $\run\, \sem f\, v \bind_L \lambda r. r\, (\lambda o. \stream r)\, (\run\, \sem g)\, (\lambda b. \stream r)$ |
-| $\irlb{label}{x} | f$ | $\labelf \fresh\, ((\lambda \$x\, \fresh. \run\, \sem f\, v)\, \fresh\, (\operatorname{succ}\, \fresh))$ |
-| $\irlb{break}{x}$ | $\stream{\irlb{break}{x}}$ |
-| $\irite{\$x}{f}{g}$ | $\run\, ((\bool\, \$x)\, \sem f\, \sem g)\, v$ |
+| $f \jqas \$x | g$ | $\run\, \sem f\, v \bind (\lambda \$x. \run, \sem g\, v)$ |
+| $\jqtc{f}{g}$ | $\run\, \sem f\, v \bind_L \lambda r. r\, (\lambda o. \stream r)\, (\run\, \sem g)\, (\lambda b. \stream r)$ |
+| $\jqlb{label}{x} | f$ | $\labelf \fresh\, ((\lambda \$x\, \fresh. \run\, \sem f\, v)\, \fresh\, (\operatorname{succ}\, \fresh))$ |
+| $\jqlb{break}{x}$ | $\stream{\jqlb{break}{x}}$ |
+| $\jqite{\$x}{f}{g}$ | $\run\, ((\bool\, \$x)\, \sem f\, \sem g)\, v$ |
 | $.[p]^?$ | $v[p]^?$ |
-| $\irfold{reduce }{f_x}{\$x}{(.; f   )}$ | $\reducef \, (\lambda \$x. \run\, \sem f)\, (\run\, \sem{f_x}\, v)\, v$ |
-| $\irfold{foreach}{f_x}{\$x}{(.; f; g)}$ | $\foreachf\, (\lambda \$x. \run\, \sem f)\, (\lambda \$x. \run\, \sem g)\, (\run\, \sem{f_x}\, v)\, v$ |
-| $\irdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \run\, \sem g\, v) (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
+| $\jqfold{reduce }{f_x}{\$x}{(.; f   )}$ | $\reducef \, (\lambda \$x. \run\, \sem f)\, (\run\, \sem{f_x}\, v)\, v$ |
+| $\jqfold{foreach}{f_x}{\$x}{(.; f; g)}$ | $\foreachf\, (\lambda \$x. \run\, \sem f)\, (\lambda \$x. \run\, \sem g)\, (\run\, \sem{f_x}\, v)\, v$ |
+| $\jqdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \run\, \sem g\, v) (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
 | $x(f_1; ...; f_n)$ | $\run\, (x\, \sem{f_1}\, ...\, \sem{f_n})\, v$ |
 | $f \update g$ | $\upd\, \sem f\, (\run\, \sem g)\, v$ |
 
@@ -85,7 +85,7 @@ Let us discuss its different cases:
 - $\$x$: Returns the value currently bound to the variable $\$x$.
   Wellformedness of the filter (as defined in @sec:mir) ensures that
   whenever we evaluate $\$x$, it must have been substituted,
-  for example by a surrounding call to $f \iras \$x | g$.
+  for example by a surrounding call to $f \jqas \$x | g$.
 - $[]$ or $\{\}$: Creates an empty array or object.
 - $[f]$: Creates an array from the output of $f$, using the function $\arr$ defined in @sec:values.
 - $\{\$x: \$y\}$: Creates an object from the values bound to $\$x$ and $\$y$,
@@ -106,28 +106,28 @@ Let us discuss its different cases:
   Here, we use a function $\trues\, x$ that
   returns its input $x$ if its boolean value is true.
   $$\trues: \valt \to \listt \coloneq \lambda x. (\bool\, x)\, \stream{\ok\, x}\, \stream{}$$
-- $f \iras \$x | g$: For every output of $f$, binds it to the variable $\$x$ and
+- $f \jqas \$x | g$: For every output of $f$, binds it to the variable $\$x$ and
   returns the output of $g$, where $g$ may reference $\$x$.
   Unlike $f | g$, this runs $g$ with the original input value instead of an output of $f$.
   We can show that the evaluation of $f | g$ is equivalent to that of
-  $f \iras \$x' | \$x' | g$, where $\$x'$ is a fresh variable.
+  $f \jqas \$x' | \$x' | g$, where $\$x'$ is a fresh variable.
   Therefore, we could be tempted to lower $f | g$ to
-  $\floor f \iras \$x' | \$x' | \floor g$ in @tab:lowering,
+  $\floor f \jqas \$x' | \$x' | \floor g$ in @tab:lowering,
   in order to further simplify IR and thus the semantics.
   However, we cannot do this because we will see in @sec:updates that
   this equivalence does _not_ hold for updates; that is,
   $(f | g) \update \sigma$ is _not_ equal to
-  $(f \iras \$x' | \$x' | g) \update \sigma$.
-- $\irtc{f}{g}$: Replaces all outputs of $f$ that equal $\err\, e$ for some $e$
+  $(f \jqas \$x' | \$x' | g) \update \sigma$.
+- $\jqtc{f}{g}$: Replaces all outputs of $f$ that equal $\err\, e$ for some $e$
   by the output of $g$ on the input $e$.
   At first sight, this seems to diverge from jq, which
   aborts the evaluation of $f$ after the first error.
   However, because lowering to IR replaces
   $\jqkw{try} f \jqkw{catch} g$ with
-  $\irlb{label}{x'} | \irtc{f}{(g, \irlb{break}{x'})}$ (see @tab:lowering),
+  $\jqlb{label}{x'} | \jqtc{f}{(g, \jqlb{break}{x'})}$ (see @tab:lowering),
   the overall behaviour described here corresponds to jq after all.
-- $\irlb{label}{x} | f$: Returns all values yielded by $f$ until $f$ yields
-  an exception $\irlb{break}{x}$.
+- $\jqlb{label}{x} | f$: Returns all values yielded by $f$ until $f$ yields
+  an exception $\jqlb{break}{x}$.
   This uses a function $\labelf$ that
   takes a label $\fresh$ and a list $l$ of value results,
   returning the longest prefix of $l$ that does not contain $\breakf\, \fresh$:
@@ -137,20 +137,20 @@ Let us discuss its different cases:
   \end{align*}
   In this function, $c$ gets bound to $\stream h  + \labelf\, \fresh\, t$,
   which is the function output when the head $h$ is not equal to $\labelf\, \fresh$.
-- $\irlb{break}{x}$: Returns a value result $\irlb{break}{x}$.
+- $\jqlb{break}{x}$: Returns a value result $\jqlb{break}{x}$.
   Similarly to the evaluation of variables $\$x$ described above,
   wellformedness of the filter (as defined in @sec:hir) ensures that
-  the returned value $\irlb{break}{x}$ will be
+  the returned value $\jqlb{break}{x}$ will be
   eventually handled by a corresponding filter
-  $\irlb{label}{x} | f$.
+  $\jqlb{label}{x} | f$.
   That means that $\eval \sem \varphi$ for a wellformed filter $\varphi$ can only yield
   values and errors, but never a break result.
-- $\irite{\$x}{f}{g}$: Returns the output of $f$ if $\$x$ is bound to
+- $\jqite{\$x}{f}{g}$: Returns the output of $f$ if $\$x$ is bound to
   a "true" value (neither null nor false for JSON, see @sec:simple-fns), else returns the output of $g$.
 - $.[p]^?$: Accesses parts of the input value;
   see @sec:value-ops for the definitions of the operators.
   When evaluating this, the indices contained in $p$ have been substituted by values.
-- $\irfold{\fold}{f_x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $f_x$,
+- $\jqfold{\fold}{f_x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $f_x$,
   starting with the current input as accumulator.
   The current accumulator value is provided to $f$ as input value and
   $f$ can access the current value of $f_x$ by $\$x$.
@@ -159,31 +159,31 @@ Let us discuss its different cases:
   We will further explain this and define the functions
   $\reducef  f\,     l\, v$ and
   $\foreachf f\, g\, l\, v$ in @sec:folding.
-- $\irdef{x(x_1; ...; x_n)}{f} g$: Binds the $n$-ary filter $x$ in $g$.
+- $\jqdef{x(x_1; ...; x_n)}{f} g$: Binds the $n$-ary filter $x$ in $g$.
   The definition of $x$, namely $f$, may refer to
   any of the arguments $x_i$ as well as to $x$ itself.
   In other words, filters can be defined recursively,
   which is why we use the Y combinator $Y_{n+1}$ here.
   @ex:recursion shows how a recursive call is evaluated.
 - $x(f_1; ...; f_n)$: Calls an $n$-ary filter $x$.
-  This also handles the case of calling nullary filters such as $\irf{empty}$.
+  This also handles the case of calling nullary filters such as $\jqf{empty}$.
 - $f \update g$: Updates the input at positions returned by $f$ by $g$.
   We will discuss this in @sec:updates.
 
 An implementation may also define semantics for builtin named filters.
 For example, an implementation may define
-$\run\, \sem{\irf{error}}\, v \coloneq \stream{\err\, v}$ and
-$\run\, \sem{\irf{keys }}\, v \coloneq \stream{\arr\, (\keys\, v)}$, see @sec:simple-fns.
-In the case of $\irf{keys}$, for example, there is no obvious way to implement it by definition,
+$\run\, \sem{\jqf{error}}\, v \coloneq \stream{\err\, v}$ and
+$\run\, \sem{\jqf{keys }}\, v \coloneq \stream{\arr\, (\keys\, v)}$, see @sec:simple-fns.
+In the case of $\jqf{keys}$, for example, there is no obvious way to implement it by definition,
 in particular because there is no simple way to obtain the domain of an object $\{...\}$
 using only the filters for which we gave semantics in @tab:eval-semantics.
 
 ::: {.example #ex:recursion name="Recursion"}
-  Consider the following IR filter $\varphi$: $$\irdef{\irf{repeat}}{., \irf{repeat}} \irf{repeat}$$
+  Consider the following IR filter $\varphi$: $$\jqdef{\jqf{repeat}}{., \jqf{repeat}} \jqf{repeat}$$
   This filter repeatedly outputs its input;
   for example, given the input $v = 1$, it returns $\stream{\ok 1, \ok 1, \ok 1, ...}$.
   First, let us compile a part of our filter, namely
-  $$\rho = \sem{., \irf{repeat}} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run\, \irf{repeat}\, v)\, (...).$$
+  $$\rho = \sem{., \jqf{repeat}} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run\, \jqf{repeat}\, v)\, (...).$$
   Here, the second part of the pair $(...)$ does not matter, because
   it is never evaluated due to our not performing any updates in this example.
 
@@ -194,13 +194,13 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
   $\eval\, \sem \varphi\, v$ is equivalent to:
   \begin{align*}
   \run\, \sem \varphi\, v
-  &= (\lambda \irf{repeat}. \run\, \sem{\irf{repeat}}\, v)\, (Y_1\, (\lambda \irf{repeat}. \rho)) \\
-  &=^{\sem \cdot} (\lambda \irf{repeat}. \run\, \irf{repeat}\, v)\, (Y_1\, (\lambda \irf{repeat}. \rho)) \\
-  &=^\beta \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v \\
-  &=^{Y_1} \run\, ((\lambda \irf{repeat}. \rho)\, (Y_1\, (\lambda \irf{repeat}. \rho)))\, v \\
-  &=^\rho \run\, ((\lambda \irf{repeat}. \pair\, (\lambda v. \stream{\ok v} + \run\, \irf{repeat}\, v)\, (...))\, (Y_1\, (\lambda \irf{repeat}. \rho)))\, v \\
-  &=^\beta \run\, (\pair\, (\lambda v. \stream{\ok v} + \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v)\, (...))\, v \\
-  &=^\beta \stream{\ok v} + \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v \\
+  &= (\lambda \jqf{repeat}. \run\, \sem{\jqf{repeat}}\, v)\, (Y_1\, (\lambda \jqf{repeat}. \rho)) \\
+  &=^{\sem \cdot} (\lambda \jqf{repeat}. \run\, \jqf{repeat}\, v)\, (Y_1\, (\lambda \jqf{repeat}. \rho)) \\
+  &=^\beta \run\, (Y_1\, (\lambda \jqf{repeat}. \rho))\, v \\
+  &=^{Y_1} \run\, ((\lambda \jqf{repeat}. \rho)\, (Y_1\, (\lambda \jqf{repeat}. \rho)))\, v \\
+  &=^\rho \run\, ((\lambda \jqf{repeat}. \pair\, (\lambda v. \stream{\ok v} + \run\, \jqf{repeat}\, v)\, (...))\, (Y_1\, (\lambda \jqf{repeat}. \rho)))\, v \\
+  &=^\beta \run\, (\pair\, (\lambda v. \stream{\ok v} + \run\, (Y_1\, (\lambda \jqf{repeat}. \rho))\, v)\, (...))\, v \\
+  &=^\beta \stream{\ok v} + \run\, (Y_1\, (\lambda \jqf{repeat}. \rho))\, v \\
   &= \stream{\ok v} + \run\, \sem \varphi\, v.
   \end{align*}
   This shows that the evaluation of $\varphi$ on any input $v$ yields
@@ -208,18 +208,18 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
 :::
 
 ::: {.example #ex:labels name="Labels"}
-  Let us consider the filter $\varphi \equiv \rsep \irlb{label}{x} | \irlb{break}{x}$.
+  Let us consider the filter $\varphi \equiv \rsep \jqlb{label}{x} | \jqlb{break}{x}$.
   We have:
   \begin{align*}
   \eval\, \sem \varphi\, v
-  &= (\lambda \fresh. \run \sem{\irlb{label}{x} | \irlb{break}{x}})\, \zero\, v \\
-  &= (\lambda \fresh\, v. \labelf\, \fresh\, ((\lambda \$x\, \fresh. \run\, \sem{\irlb{break}{x}}\, v)\, \fresh\, (\succf\, \fresh)))\, \zero\, v \\
-  &= \labelf\, \zero\, ((\lambda \$x\, \fresh. \stream{\irlb{break}{x}})\, \zero\, (\succf\, \zero)) \\
+  &= (\lambda \fresh. \run \sem{\jqlb{label}{x} | \jqlb{break}{x}})\, \zero\, v \\
+  &= (\lambda \fresh\, v. \labelf\, \fresh\, ((\lambda \$x\, \fresh. \run\, \sem{\jqlb{break}{x}}\, v)\, \fresh\, (\succf\, \fresh)))\, \zero\, v \\
+  &= \labelf\, \zero\, ((\lambda \$x\, \fresh. \stream{\jqlb{break}{x}})\, \zero\, (\succf\, \zero)) \\
   &= \labelf\, \zero\, \stream{\breakf \zero} \\
   &= \stream{}
   \end{align*}
-  It is interesting to note that if instead of $\irlb{break}{x}$,
-  we would have used a more complex filter, e.g. $\irlb{label}{y} | ...$,
+  It is interesting to note that if instead of $\jqlb{break}{x}$,
+  we would have used a more complex filter, e.g. $\jqlb{label}{y} | ...$,
   then $\$y$ would have been substituted by $\succf\, \zero$
   (which we can already see in our large equation above).
   This mechanism reliably allows us to generate fresh labels and to
@@ -230,8 +230,8 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
 
 In this subsection, we will define the functions
 $\reducef$ and $\foreachf$ which underlie the semantics for the folding operators
-$\irfold{reduce }{f_x}{\$x}{(.; f)}$ and
-$\irfold{foreach}{f_x}{\$x}{(.; f; g)}$.
+$\jqfold{reduce }{f_x}{\$x}{(.; f)}$ and
+$\jqfold{foreach}{f_x}{\$x}{(.; f; g)}$.
 
 \newcommand{\foldf}{\operatorname{fold}}
 Let us start by defining a general folding function $\foldf$:
@@ -270,21 +270,21 @@ We will now look at what the evaluation of the various folding filters expands t
 Assuming that the filter $f_x$ evaluates to $\stream{x_0, ..., x_n}$,
 then $\jqf{reduce}$ and $\jqf{foreach}$ expand to
 \begin{alignat*}{2}
-\irfold{reduce }{f_x}{\$x}{(.; f   )} ={}& x_0 \iras \$x | f & \quad
-\irfold{foreach}{f_x}{\$x}{(.; f; g)} ={}& x_0 \iras \$x | f | g, ( \\
+\jqfold{reduce }{f_x}{\$x}{(.; f   )} ={}& x_0 \jqas \$x | f & \quad
+\jqfold{foreach}{f_x}{\$x}{(.; f; g)} ={}& x_0 \jqas \$x | f | g, ( \\
 |\; & ... &
     & ... \\
-|\; & x_n \iras \$x | f &
-    & x_n \iras \$x | f | g, ( \\
+|\; & x_n \jqas \$x | f &
+    & x_n \jqas \$x | f | g, ( \\
     &     &
-    & \irf{empty})...)
+    & \jqf{empty})...)
 \end{alignat*}
 Note that jq implements only restricted versions of these folding operators
 that consider only the last output of $f$ for the next iteration.
 That means that in jq,
-$\irfold{reduce}{f_x}{\$x}{(.;            f )}$ is equivalent to
-$\irfold{reduce}{f_x}{\$x}{(.; \irf{last}(f))}$.
-Here, we assume that the filter $\irf{last}(f)$
+$\jqfold{reduce}{f_x}{\$x}{(.;            f )}$ is equivalent to
+$\jqfold{reduce}{f_x}{\$x}{(.; \jqf{last}(f))}$.
+Here, we assume that the filter $\jqf{last}(f)$
 returns the last output of $f$ if $f$ yields any output, else nothing.
 
 
@@ -387,17 +387,17 @@ Table: Update semantics properties. {#tab:update-props}
 
 | $\varphi$ | $\varphi \update \sigma$ |
 | --------- | ------------------------ |
-| $\irf{empty}$ | $.$ |
+| $\jqf{empty}$ | $.$ |
 | $.$ | $\sigma$ |
 | $f | g$ | $f \update (g \update \sigma)$ |
 | $f, g$ | $(f \update \sigma) | (g \update \sigma)$ |
-| $\irite{\$x}{f}{g}$ | $\irite{\$x}{f \update \sigma}{g \update \sigma}$ |
-| $f \alt g$ | $\irite{\irf{first}(f \alt \irf{null})}{f \update \sigma}{g \update \sigma}$ |
+| $\jqite{\$x}{f}{g}$ | $\jqite{\$x}{f \update \sigma}{g \update \sigma}$ |
+| $f \alt g$ | $\jqite{\jqf{first}(f \alt \jqf{null})}{f \update \sigma}{g \update \sigma}$ |
 
 @tab:update-props gives a few properties that we want to hold for updates $\varphi \update \sigma$.
 Let us discuss these for the different filters $\varphi$:
 
-- $\irf{empty}$: Returns the input unchanged.
+- $\jqf{empty}$: Returns the input unchanged.
 - "$.$": Returns the output of the update filter $\sigma$ applied to the current input.
   Note that while jq only returns at most one output of $\sigma$,
   these semantics return an arbitrary number of outputs.
@@ -407,9 +407,9 @@ Let us discuss these for the different filters $\varphi$:
   $.[] \update (.[] \update \sigma)$, yielding the same output as in the example.
 - $f, g$: Applies the update of $\sigma$ at $g$ to the output of the update of $\sigma$ at $f$.
   We have already seen this at the end of @sec:jq-updates.
-- $\irite{\$x}{f}{g}$: Applies $\sigma$ at $f$ if $\$x$ holds, else at $g$.
+- $\jqite{\$x}{f}{g}$: Applies $\sigma$ at $f$ if $\$x$ holds, else at $g$.
 - $f \alt g$: Applies $\sigma$ at $f$ if $f$ yields some output whose boolean value (see @sec:simple-fns) is not false, else applies $\sigma$ at $g$.
-  Here, $\irf{first}(f)$ is a filter that returns
+  Here, $\jqf{first}(f)$ is a filter that returns
   the first output of its argument $f$ if there is one, else the empty list.
 
 While @tab:update-props allows us to define the behaviour of several filters
@@ -425,19 +425,19 @@ To define $\upd\, \sem \varphi\, \sigma\, v$, we first have to understand
 how to prevent unwanted interactions between $\varphi$ and $\sigma$.
 In particular, we have to look at variable bindings.
 
-We can bind variables in $\varphi$; that is, $\varphi$ can have the shape $f \iras \$x | g$.
+We can bind variables in $\varphi$; that is, $\varphi$ can have the shape $f \jqas \$x | g$.
 Here, the intent is that $g$ has access to $\$x$, whereas $\sigma$ does not!
 This is to ensure compatibility with jq's original semantics,
 which execute $\varphi$ and $\sigma$ independently,
 so $\sigma$ should not be able to access variables bound in $\varphi$.
 
 ::: {.example}
-  Consider the filter $0 \iras \$x | \varphi \update \sigma$, where
-  $\varphi$ is $(1 \iras \$x | .[\$x])$ and $\sigma$ is $\$x$.
+  Consider the filter $0 \jqas \$x | \varphi \update \sigma$, where
+  $\varphi$ is $(1 \jqas \$x | .[\$x])$ and $\sigma$ is $\$x$.
   This updates the input array at index $1$.
   If $\sigma$ had access to variables bound in $\varphi$,
   then the array element would be replaced by $1$,
-  because the variable binding $0 \iras \$x$ would be shadowed by $1 \iras \$x$.
+  because the variable binding $0 \jqas \$x$ would be shadowed by $1 \jqas \$x$.
   However, in jq, $\sigma$ does not have access to variables bound in $\varphi$, so
   the array element is replaced by $0$, which is the value originally bound to $\$x$.
   Given the input array $[1, 2, 3]$, the filter yields the final result $[1, 0, 3]$.
@@ -472,17 +472,17 @@ Table: Update semantics. Here, $\varphi$ is a filter and $\sigma: \valt \to \lis
 | $f, g$ | $\upd\, \sem f\, \sigma\, v \bind \upd\, \sem g\, \sigma$ |
 | $f \alt g$ | $\upd\, ((\run\, \sem f\, v \bind \trues)\, (\lambda \_\, \_. \sem f)\, \sem g)\, \sigma\, v$ |
 | $.[p]^?$ | $\stream{v[p]^? \update \sigma}$ |
-| $f \iras \$x | g$ | $\reducef\, (\lambda \$x. \upd\, \sem g\, \sigma)\, (\run\, \sem f\, v)\, v$ |
-| $\irite{\$x}{f}{g}$ | $\upd\, ((\bool\, \$x)\, \sem f\, \sem g)\, \sigma\, v$ |
-| $\irlb{break}{x}$ | $\stream{\breakf\, \$x}$ |
-| $\irfold{reduce}{x}{\$x}{(.; f)}$ | $\reducef_{\update}\, (\lambda \$x. \upd\, \sem f)\, \sigma\, (\run\, \sem x\, v)\, v$ |
-| $\irfold{foreach}{x}{\$x}{(.; f; g)}$ | $\foreachf_{\update}\, (\lambda \$x. \upd\, \sem f)\, (\lambda \$x. \upd\, \sem g)\, \sigma\, (\run\, \sem x\, v)\, v$ |
-| $\irdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \upd\, \sem g\, \sigma\, v)\, (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
+| $f \jqas \$x | g$ | $\reducef\, (\lambda \$x. \upd\, \sem g\, \sigma)\, (\run\, \sem f\, v)\, v$ |
+| $\jqite{\$x}{f}{g}$ | $\upd\, ((\bool\, \$x)\, \sem f\, \sem g)\, \sigma\, v$ |
+| $\jqlb{break}{x}$ | $\stream{\breakf\, \$x}$ |
+| $\jqfold{reduce}{x}{\$x}{(.; f)}$ | $\reducef_{\update}\, (\lambda \$x. \upd\, \sem f)\, \sigma\, (\run\, \sem x\, v)\, v$ |
+| $\jqfold{foreach}{x}{\$x}{(.; f; g)}$ | $\foreachf_{\update}\, (\lambda \$x. \upd\, \sem f)\, (\lambda \$x. \upd\, \sem g)\, \sigma\, (\run\, \sem x\, v)\, v$ |
+| $\jqdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \upd\, \sem g\, \sigma\, v)\, (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
 | $x(f_1; ...; f_n)$ | $\upd\, (x\, \sem{f_1}\, ...\, \sem{f_n})\, \sigma\, v$ |
 
 @tab:update-semantics shows the definition of $\upd\, \sem \varphi\, \sigma\, v$.
 Several of the cases for $\varphi$, like
-"$.$", "$f | g$", "$f, g$", and "$\irite{\$x}{f}{g}$"
+"$.$", "$f | g$", "$f, g$", and "$\jqite{\$x}{f}{g}$"
 are simply relatively straightforward consequences of the properties in @tab:update-props.
 We discuss the remaining cases for $\varphi$:
 
@@ -496,14 +496,14 @@ We discuss the remaining cases for $\varphi$:
   updated with ($\upd\, \sem f\, \sigma\, v$).
 - $.[p]^?$: Applies $\sigma$ to the current value at the path part $p$
   using the update operators in @sec:value-ops.
-- $f \iras \$x | g$:
+- $f \jqas \$x | g$:
   Folds over all outputs of $f$, using the input value $v$ as initial accumulator and
   updating the accumulator by $g \update \sigma$, where
   $\$x$ is bound to the current output of $f$.
   The definition of $\reducef$ is given in @sec:folding.
-- $\irfold{\fold}{x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $\$x$.
+- $\jqfold{\fold}{x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $\$x$.
   We will discuss this in @sec:folding-update.
-- $\irdef{x(x_1; ...; x_n)}{f} g$: Defines a filter.
+- $\jqdef{x(x_1; ...; x_n)}{f} g$: Defines a filter.
   This is defined analogously to @tab:eval-semantics.
 - $x(f_1; ...; f_n)$, $x$: Calls a filter.
   This is defined analogously to @tab:eval-semantics.
@@ -514,7 +514,7 @@ for example $\$x$, $[f]$, and $\{\}$.
 In such cases, we assume that $\upd\, \sem \varphi\, \sigma\, v$ returns an error just like jq,
 because these filters do not return paths to their input data.
 Our update semantics support all kinds of filters $\varphi$ that are supported by jq, except for
-$\irlb{label}{x} | g$ and $\irtc{f}{g}$.
+$\jqlb{label}{x} | g$ and $\jqtc{f}{g}$.
 
 ::: {.example name="Update compilation"}
   Let us consider the jq filter $(.[] \update .+.)$.
@@ -524,8 +524,8 @@ $\irlb{label}{x} | g$ and $\irtc{f}{g}$.
   effectively doubling its input.
   For example, when given the input $[1, 2, 3]$, the output of $\varphi$ is $[2, 4, 6]$.
   Before we can execute the jq filter, we have to lower it to IR, e.g. to
-  $\varphi \equiv (.[] \update (. \iras \$x | \$x + \$x))$.^[
-    Note that the actual lowering $(.[] \update (. \iras \$x | . \iras \$y | \$x + \$y))$
+  $\varphi \equiv (.[] \update (. \jqas \$x | \$x + \$x))$.^[
+    Note that the actual lowering $(.[] \update (. \jqas \$x | . \jqas \$y | \$x + \$y))$
     is a bit longer than the $\varphi$ given here, but
     because the two are semantically equivalent, we continue with $\varphi$.
   ]
@@ -533,10 +533,10 @@ $\irlb{label}{x} | g$ and $\irtc{f}{g}$.
   $\eval\, \sem \varphi\, v = (\lambda \fresh. \run\, \sem \varphi)\, \zero\, v$.
   Because $\varphi$ does not use any labels,
   this is equivalent to just $\run\, \sem \varphi\, v = \upd\, \sem{(.[])}\, \sigma\, v = (v[] \update \sigma)$.
-  Here, we introduced $\sigma \equiv \run\, \sem{. \iras \$x | \$x + \$x}$.
+  Here, we introduced $\sigma \equiv \run\, \sem{. \jqas \$x | \$x + \$x}$.
   We can further expand $\sigma$:
   \begin{align*} \sigma
-  &= \lambda v. \run\, \sem{. \iras \$x | \$x + \$x}\, v \\
+  &= \lambda v. \run\, \sem{. \jqas \$x | \$x + \$x}\, v \\
   &= \lambda v. \run\, \sem{.} \bind (\lambda \$x. \run\, \sem{\$x + \$x}\, v) \\
   &= \lambda v. \stream{\ok v} \bind (\lambda \$x. \stream{\$x + \$x}) \\
   &= \lambda v. \stream(v + v)
@@ -577,17 +577,17 @@ $\irlb{label}{x} | g$ and $\irtc{f}{g}$.
 
   Finally, on the input
   $[]$, the filter
-  $(.[] \alt \irf{error}) \update 1$ yields
+  $(.[] \alt \jqf{error}) \update 1$ yields
   $\stream{\err\, []}$.
   That is because $.[]$ does not yield any value for the input,
-  so $\irf{error} \update 1$ is executed, which yields an error.
+  so $\jqf{error} \update 1$ is executed, which yields an error.
 :::
 
 ## Folding {#sec:folding-update}
 
 In @sec:folding, we have seen how to evaluate folding filters of the shape
-$\irfold{reduce }{x}{\$x}{(.; f)}$ and
-$\irfold{foreach}{x}{\$x}{(.; f; g)}$.
+$\jqfold{reduce }{x}{\$x}{(.; f)}$ and
+$\jqfold{foreach}{x}{\$x}{(.; f; g)}$.
 Here, we will define update semantics for these filters.
 These update operations are _not_ supported in jq 1.7; however,
 we will show that they arise quite naturally from previous definitions.
@@ -596,7 +596,7 @@ Let us start with an example to understand folding on the left-hand side of an u
 
 ::: {.example #ex:folding-update}
   Let $v = [[[2], 1], 0]$ be our input value
-  and $\varphi$ be the filter $\irfold{\fold}{(0, 0)}{\$x}{(.; .[\$x])}$.
+  and $\varphi$ be the filter $\jqfold{\fold}{(0, 0)}{\$x}{(.; .[\$x])}$.
   The regular evaluation of $\varphi$ with the input value as described in @sec:semantics yields
   $$\run\, \sem \varphi\, v = \begin{cases}
     \stream{\phantom{[[2], 1],\,} [2]} & \text{if } \fold = \jqf{reduce} \\
@@ -617,40 +617,40 @@ the lowering in @tab:lowering and
 the defining equations in @sec:folding
 only make use of filters for which we have already introduced update semantics in @tab:update-semantics.
 This should not be taken for granted; for example, we originally lowered
-$\irfold{\fold}{f_x}{\$x}{(f_y; f)}$ to
-$$\floor{f_y} \iras \$y | \irfold{\fold}{\floor{f_x}}{\$x}{(\$y; \floor{f})}$$
+$\jqfold{\fold}{f_x}{\$x}{(f_y; f)}$ to
+$$\floor{f_y} \jqas \$y | \jqfold{\fold}{\floor{f_x}}{\$x}{(\$y; \floor{f})}$$
 instead of the more complicated lowering found in @tab:lowering, namely
-$$. \iras \$x' | \floor{f_y} | \irfold{\fold}{\floor{\$x' | f_x}}{\$x}{(.; \floor{f})}.$$
+$$. \jqas \$x' | \floor{f_y} | \jqfold{\fold}{\floor{\$x' | f_x}}{\$x}{(.; \floor{f})}.$$
 While both lowerings produce the same output for regular evaluation,
 we cannot use the original lowering for updates, because the defining equations for
-$\irfold{\fold}{x}{\$x}{(\$y; f)}$ would have the shape $\$y | ...$,
+$\jqfold{\fold}{x}{\$x}{(\$y; f)}$ would have the shape $\$y | ...$,
 which is undefined on the left-hand side of an update.
 However, the lowering in @tab:lowering avoids this issue
 by not binding the output of $f_y$ to a variable,
 so it can be used on the left-hand side of updates.
 
 To obtain an intuition about how the update evaluation of a fold looks like, we can take
-$\irfold{\fold}{x}{\$x}{(.; f; g)} \update \sigma$,
+$\jqfold{\fold}{x}{\$x}{(.; f; g)} \update \sigma$,
 substitute the left-hand side by the defining equations in @sec:folding and
 expand everything using the properties in @sec:update-props.
 This yields
 \begin{alignat*}{2}
-\irfold{reduce}{x}{\$x}{(.; f   )} \update \sigma
-={}& x_0 \iras \$x | (f \update ( \\
+\jqfold{reduce}{x}{\$x}{(.; f   )} \update \sigma
+={}& x_0 \jqas \$x | (f \update ( \\
  & ... \\
- & x_n \iras \$x | (f \update (  \\
+ & x_n \jqas \$x | (f \update (  \\
  & \sigma))...)) \\
-\irfold{foreach}{x}{\$x}{(.; f; g)} \update \sigma
-={}& x_0 \iras \$x | (f \update ((g \update \sigma) | \\
+\jqfold{foreach}{x}{\$x}{(.; f; g)} \update \sigma
+={}& x_0 \jqas \$x | (f \update ((g \update \sigma) | \\
  & ... \\
- & x_n \iras \$x | (f \update ((g \update \sigma) | \\
+ & x_n \jqas \$x | (f \update ((g \update \sigma) | \\
  & .))...)).
 \end{alignat*}
 
 ::: {.example}
   To see the effect of above equations, let us reconsider
   the input value and the filters from @ex:folding-update.
-  Using some liberty to write $.[0]$ instead of $0 \iras \$x | .[\$x]$, we have:
+  Using some liberty to write $.[0]$ instead of $0 \jqas \$x | .[\$x]$, we have:
   $$\varphi \update \sigma = \begin{cases}
     .[0] \update \phantom{\sigma | (}.[0] \update \sigma   & \text{if } \fold = \jqf{reduce} \\
     .[0] \update          \sigma | ( .[0] \update \sigma)  & \text{if } \fold = \jqf{foreach}

--- a/semantics.md
+++ b/semantics.md
@@ -162,7 +162,7 @@ Let us discuss its different cases:
   which is why we use the Y combinator $Y_{n+1}$ here.
   @ex:recursion shows how a recursive call is evaluated.
 - $x(f_1; ...; f_n)$: Calls an $n$-ary filter $x$.
-  This also handles the case of calling nullary filters such as $\empty$.
+  This also handles the case of calling nullary filters such as $\emptyf$.
 - $f \update g$: Updates the input at positions returned by $f$ by $g$.
   We will discuss this in @sec:updates.
 
@@ -279,7 +279,7 @@ then $\reduce$ and $\foreac$ expand to
 |\; & x_n \as \$x | f &
     & x_n \as \$x | f | g, ( \\
     &     &
-    & \empty)...)
+    & \emptyf)...)
 \end{alignat*}
 Note that jq implements only restricted versions of these folding operators
 that consider only the last output of $f$ for the next iteration.

--- a/semantics.md
+++ b/semantics.md
@@ -109,7 +109,7 @@ Let us discuss its different cases:
   $f \as \$x' | \$x' | g$, where $\$x'$ is a fresh variable.
   Therefore, we could be tempted to lower $f | g$ to
   $\floor f  \as \$x' | \$x' | \floor g$ in @tab:lowering,
-  in order to further simplify MIR and thus the semantics.
+  in order to further simplify IR and thus the semantics.
   However, we cannot do this because we will see in @sec:updates that
   this equivalence does _not_ hold for updates; that is,
   $(f | g) \update \sigma$ is _not_ equal to
@@ -118,8 +118,8 @@ Let us discuss its different cases:
   by the output of $g$ on the input $e$.
   At first sight, this seems to diverge from jq, which
   aborts the evaluation of $f$ after the first error.
-  However, because lowering to MIR replaces
-  $\try f \catch g$ with
+  However, because lowering to IR replaces
+  $\jqkw{try} f \jqkw{catch} g$ with
   $\labelx{x'} | \try f \catch (g, \breakx{x'})$ (see @tab:lowering),
   the overall behaviour described here corresponds to jq after all.
 - $\labelx x | f$: Returns all values yielded by $f$ until $f$ yields
@@ -175,7 +175,7 @@ in particular because there is no simple way to obtain the domain of an object $
 using only the filters for which we gave semantics in @tab:eval-semantics.
 
 ::: {.example #ex:recursion name="Recursion"}
-  Consider the following MIR filter $\varphi$: $$\deff \repeatf: ., \repeatf; \repeatf$$
+  Consider the following IR filter $\varphi$: $$\deff \repeatf: ., \repeatf; \repeatf$$
   This filter repeatedly outputs its input;
   for example, given the input $v = 1$, it returns $\stream{\ok 1, \ok 1, \ok 1, ...}$.
   First, let us compile a part of our filter, namely
@@ -519,15 +519,16 @@ Our update semantics support all kinds of filters $\varphi$ that are supported b
 $\labelx x | g$ and $\try f \catch g$.
 
 ::: {.example name="Update compilation"}
-  Let us consider the filter $\varphi' \equiv (.[] \update .+.)$.
+  Let us consider the jq filter `(.[] |= .+.)`.
   When given an array as input, this filter outputs a new array where
   each value in the input array is replaced by the output of $.+.$ on the value.
   The filter $.+.$ returns the sum of the input and the input,
   effectively doubling its input.
   For example, when given the input $[1, 2, 3]$, the output of $\varphi$ is $[2, 4, 6]$.
-  Before we can execute $\varphi'$, we have to convert it to MIR, e.g. to
-  $\varphi \equiv .[] \update (. \as \$x | \$x + \$x)$.^[
-    Note that $\floor{\varphi'} = (.[] \update (. \as \$x | . \as \$y | \$x + \$y))$ is a bit longer than the $\varphi$ given here, but
+  Before we can execute the jq filter, we have to lower it to IR, e.g. to
+  $\varphi \equiv (.[] \update (. \as \$x | \$x + \$x))$.^[
+    Note that the actual lowering $(.[] \update (. \as \$x | . \as \$y | \$x + \$y))$
+    is a bit longer than the $\varphi$ given here, but
     because the two are semantically equivalent, we continue with $\varphi$.
   ]
   Let us now trace the execution of the filter, namely

--- a/semantics.md
+++ b/semantics.md
@@ -11,9 +11,9 @@ The evaluation strategy is call-by-name.
 We will use pairs to store two functions
 --- a run and an update function --- that characterise each filter $\filtert$.
 \begin{alignat*}{4}
-  \pair&:                &(\valt \to \listt) &\to ((\valt \to \listt) \to \valt \to \listt) \to \filtert &&\coloneq \lambda x\, y\, f. f\, x\, y  \\
-   \run&: \filtert \to{} &(\valt \to \listt) &                                                           &&\coloneq \lambda p. p\, (\lambda x\, y. x) \\
-   \upd&: \filtert       &                   &\to ((\valt \to \listt) \to \valt \to \listt)              &&\coloneq \lambda p. p\, (\lambda x\, y. y)
+  \pair&:                &(\valt \to \listt) &\to ((\valt \to \listt) \to \valt \to \listt) \to \filtert &&\coloneqq \lambda x\, y\, f. f\, x\, y  \\
+   \run&: \filtert \to{} &(\valt \to \listt) &                                                           &&\coloneqq \lambda p. p\, (\lambda x\, y. x) \\
+   \upd&: \filtert       &                   &\to ((\valt \to \listt) \to \valt \to \listt)              &&\coloneqq \lambda p. p\, (\lambda x\, y. y)
 \end{alignat*}
 The lambda term $\sem \varphi$ corresponding to a filter $\varphi$ that we will define
 will always be a pair of two functions, namely a run and an update function.
@@ -43,7 +43,7 @@ This variable is used to generate fresh labels for the execution of
 $\jqlb{label}{x} | f$, see @ex:labels.
 In order to create a closed term, we initially bind $\fresh$ to zero.
 We can then run a filter using the following function:
-$$\eval: \filtert \to \valt \to \listt \coloneq \lambda \varphi. (\lambda \fresh. \run\, \varphi)\, \zero$$
+$$\eval: \filtert \to \valt \to \listt \coloneqq \lambda \varphi. (\lambda \fresh. \run\, \varphi)\, \zero$$
 
 \newcommand{\reducef }{\operatorname{reduce }}
 \newcommand{\foreachf}{\operatorname{foreach}}
@@ -105,7 +105,7 @@ Let us discuss its different cases:
   This filter returns $l$ if $l$ is not empty, else the outputs of $g$.
   Here, we use a function $\trues\, x$ that
   returns its input $x$ if its boolean value is true.
-  $$\trues: \valt \to \listt \coloneq \lambda x. (\bool\, x)\, \stream{\ok\, x}\, \stream{}$$
+  $$\trues: \valt \to \listt \coloneqq \lambda x. (\bool\, x)\, \stream{\ok\, x}\, \stream{}$$
 - $f \jqas \$x | g$: For every output of $f$, binds it to the variable $\$x$ and
   returns the output of $g$, where $g$ may reference $\$x$.
   Unlike $f | g$, this runs $g$ with the original input value instead of an output of $f$.
@@ -133,7 +133,7 @@ Let us discuss its different cases:
   returning the longest prefix of $l$ that does not contain $\breakf\, \fresh$:
   \begin{align*}
   \labelf&: \mathbb N \to \listt \to \listt \\
-         &\coloneq \lambda \fresh\, l. l\, (\lambda h\, t. (\lambda c. h\, (\lambda o. c)\, (\lambda e. c)\, (\lambda b. \operatorname{nat\_eq}\, \fresh\, b\, \stream{}\, c))\, (\stream h  + \labelf\, \fresh\, t))\, \stream()
+         &\coloneqq \lambda \fresh\, l. l\, (\lambda h\, t. (\lambda c. h\, (\lambda o. c)\, (\lambda e. c)\, (\lambda b. \operatorname{nat\_eq}\, \fresh\, b\, \stream{}\, c))\, (\stream h  + \labelf\, \fresh\, t))\, \stream()
   \end{align*}
   In this function, $c$ gets bound to $\stream h  + \labelf\, \fresh\, t$,
   which is the function output when the head $h$ is not equal to $\labelf\, \fresh$.
@@ -172,8 +172,8 @@ Let us discuss its different cases:
 
 An implementation may also define semantics for builtin named filters.
 For example, an implementation may define
-$\run\, \sem{\jqf{error}}\, v \coloneq \stream{\err\, v}$ and
-$\run\, \sem{\jqf{keys }}\, v \coloneq \stream{\arr\, (\keys\, v)}$, see @sec:simple-fns.
+$\run\, \sem{\jqf{error}}\, v \coloneqq \stream{\err\, v}$ and
+$\run\, \sem{\jqf{keys }}\, v \coloneqq \stream{\arr\, (\keys\, v)}$, see @sec:simple-fns.
 In the case of $\jqf{keys}$, for example, there is no obvious way to implement it by definition,
 in particular because there is no simple way to obtain the domain of an object $\{...\}$
 using only the filters for which we gave semantics in @tab:eval-semantics.
@@ -237,7 +237,7 @@ $\jqfold{foreach}{f_x}{\$x}{(.; f; g)}$.
 Let us start by defining a general folding function $\foldf$:
 \begin{align*}
 \foldf&: (\valt \to \valt \to \listt) \to (\valt \to \valt \to \listt) \to (\valt \to \listt) \to \listt \to \valt \to \listt \\
-&\coloneq \lambda f\, g\, n. Y_2\, (\lambda F\, l\, v. l\, (\lambda h\, t. f\, h\, v \bind (\lambda y. g\, h\, y + F\, t\, y))\, (n\, v))
+&\coloneqq \lambda f\, g\, n. Y_2\, (\lambda F\, l\, v. l\, (\lambda h\, t. f\, h\, v \bind (\lambda y. g\, h\, y + F\, t\, y))\, (n\, v))
 \end{align*}
 This function takes
 two functions $f$ and $g$ that both take two values --- a list element and an accumulator --- and return a list of value results, and
@@ -257,8 +257,8 @@ the first returns just its input, corresponding to $\jqf{reduce}$ which returns 
 the second returns nothing,  corresponding to $\jqf{foreach}$.
 Instantiating $\foldf$ with these two functions, we obtain the following:
 \begin{alignat*}{4}
-\reducef &\coloneq \lambda f.     && \foldf\, f\, (\lambda h\, v. \stream{})\, && (\lambda v. \stream{\ok v &&}) \\
-\foreachf &\coloneq \lambda f\, g. && \foldf\, f\, g\, && (\lambda v. \stream{&&})
+\reducef &\coloneqq \lambda f.     && \foldf\, f\, (\lambda h\, v. \stream{})\, && (\lambda v. \stream{\ok v &&}) \\
+\foreachf &\coloneqq \lambda f\, g. && \foldf\, f\, g\, && (\lambda v. \stream{&&})
 \end{alignat*}
 Here, $\reducef$ and $\foreachf$ are the functions used in @tab:eval-semantics.
 Their types are:
@@ -458,8 +458,8 @@ We will now give semantics that define the output of
 $\run\, \sem{f \update g}\, v$ as referred to in @sec:semantics.
 
 We will first combine the techniques in @sec:limiting-interactions to define
-$$\run\, \sem{f \update g}\, v \coloneq \upd\, \sem f\, \sigma\, v, \text{where }
-  \sigma: \valt \to \listt \coloneq \run\, \sem g$$
+$$\run\, \sem{f \update g}\, v \coloneqq \upd\, \sem f\, \sigma\, v, \text{where }
+  \sigma: \valt \to \listt \coloneqq \run\, \sem g$$
 We use the function $\sigma$ instead of a filter on the right-hand side to
 limit the scope of variable bindings as explained in @sec:limiting-interactions.
 
@@ -663,12 +663,12 @@ as counterpart to the function $\foldf$ in @sec:folding.
 Its first argument is of type $\valt \to (\valt \to \listt) \to \valt \to \listt$, which we abbreviate as $\mathcal U$:
 \begin{align*}
 \foldf_{\update}&: \mathcal U \to (\valt \to \valt \to \listt) \to (\valt \to \listt) \to \listt \to \valt \to \listt \\
-&\coloneq \lambda f\, g\, n. Y_2\, (\lambda F\, l\, v. l\, (\lambda h\, t. f\, h\, (\lambda x. g\, h\, x \bind F\, t)\, v)\, (n\, v))
+&\coloneqq \lambda f\, g\, n. Y_2\, (\lambda F\, l\, v. l\, (\lambda h\, t. f\, h\, (\lambda x. g\, h\, x \bind F\, t)\, v)\, (n\, v))
 \end{align*}
 Using this function, we can now define
 \begin{alignat*}{4}
-\reducef _{\update} &\coloneq \lambda f\,     &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. \stream{\ok v})\, && \sigma \\
-\foreachf_{\update} &\coloneq \lambda f\, g\, &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. g\, h\, \sigma\, v)\, && (\lambda v. \stream{\ok v})
+\reducef _{\update} &\coloneqq \lambda f\,     &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. \stream{\ok v})\, && \sigma \\
+\foreachf_{\update} &\coloneqq \lambda f\, g\, &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. g\, h\, \sigma\, v)\, && (\lambda v. \stream{\ok v})
 \end{alignat*}
 The types of the functions are:
 \begin{alignat*}{2}

--- a/semantics.md
+++ b/semantics.md
@@ -87,10 +87,10 @@ Let us discuss its different cases:
 - $\{\$x: \$y\}$: Creates an object from the values bound to $\$x$ and $\$y$,
   using the function $\objf_1$ defined in @sec:values.
 - $\$x \arith \$y$: Returns the output of an arithmetic operation "$\arith$"
-  (any of $+$, $-$, $\times$, $\div$, and $\%$, as given in @tab:binops)
+  (any of $+$, $-$, $\times$, $\div$, and $\%$, as given in @tab:op-correspondence)
   on the values bound to $\$x$ and $\$y$.
 - $\$x \cartesian \$y$: Returns the output of a Boolean operation "$\cartesian$"
-  (any of $\stackrel{?}{=}$, $\neq$, $<$, $\leq$, $>$, $\geq$, as given in @tab:binops)
+  (any of $\stackrel{?}{=}$, $\neq$, $<$, $\leq$, $>$, $\geq$, as given in @tab:op-correspondence)
   on the values bound to $\$x$ and $\$y$.
   Because we assumed that Boolean operations return $\valt$ and are thus infallible
   (unlike the arithmetic operations $\arith$, which return $\resultt$),
@@ -193,7 +193,7 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
   &= (\lambda \repeatf. \run\, \sem \repeatf\, v)\, (Y_1\, (\lambda \repeatf. \rho)) \\
   &=^{\sem \cdot} (\lambda \repeatf. \run\, \repeatf\, v)\, (Y_1\, (\lambda \repeatf. \rho)) \\
   &=^\beta \run\, (Y_1\, (\lambda \repeatf. \rho))\, v \\
-  &=^{Y_1} \run\, ((\lambda \repeatf. \rho)\, (app(Y_1, (\lambda(\repeatf) \rho))))\, v \\
+  &=^{Y_1} \run\, ((\lambda \repeatf. \rho)\, (Y_1\, (\lambda(\repeatf) \rho)))\, v \\
   &=^\rho \run\, ((\lambda \repeatf. \pair\, (\lambda v. \stream{\ok v} + \run \repeatf v)\, (...))\, (Y_1\, (\lambda \repeatf. \rho)))\, v \\
   &=^\beta \run\, (\pair\, (\lambda v. \stream{\ok v} + \run\, (Y_1\, (\lambda \repeatf. \rho))\, v)\, (...))\, v \\
   &=^\beta \stream{\ok v} + \run\, (Y_1\, (\lambda \repeatf. \rho))\, v \\

--- a/semantics.md
+++ b/semantics.md
@@ -183,7 +183,7 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
   This filter repeatedly outputs its input;
   for example, given the input $v = 1$, it returns $\stream{\ok 1, \ok 1, \ok 1, ...}$.
   First, let us compile a part of our filter, namely
-  $$\rho = \sem{., \irf{repeat}} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run \irf{repeat} v)\, (...).$$
+  $$\rho = \sem{., \irf{repeat}} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run\, \irf{repeat}\, v)\, (...).$$
   Here, the second part of the pair $(...)$ does not matter, because
   it is never evaluated due to our not performing any updates in this example.
 
@@ -208,7 +208,7 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
 :::
 
 ::: {.example #ex:labels name="Labels"}
-  Let us consider the filter $\varphi \equiv \irlb{label}{x} | \irlb{break}{x}$.
+  Let us consider the filter $\varphi \equiv \rsep \irlb{label}{x} | \irlb{break}{x}$.
   We have:
   \begin{align*}
   \eval\, \sem \varphi\, v

--- a/semantics.md
+++ b/semantics.md
@@ -40,10 +40,14 @@ $t_u = \sigma\, v$ was obtained from @tab:update-semantics.
 The lambda term $\sem \varphi$ obtained from a well-formed filter $\varphi$
 may contain at most one free variable, namely $\fresh$.
 This variable is used to generate fresh labels for the execution of
-$\labelx x | f$, see @ex:labels.
+$\irlb{label}{x} | f$, see @ex:labels.
 In order to create a closed term, we initially bind $\fresh$ to zero.
 We can then run a filter using the following function:
 $$\eval: \filtert \to \valt \to \listt \coloneq \lambda \varphi. (\lambda \fresh. \run\, \varphi)\, \zero$$
+
+\newcommand{\reducef }{\operatorname{reduce }}
+\newcommand{\foreachf}{\operatorname{foreach}}
+\newcommand{\labelf}{\operatorname{label}}
 
 Table: Evaluation semantics. {#tab:eval-semantics}
 
@@ -61,15 +65,15 @@ Table: Evaluation semantics. {#tab:eval-semantics}
 | $f, g$ | $\run\, \sem f\, v + \run\, \sem g\, v$ |
 | $f | g$ | $\run\, \sem f\, v \bind \run\, \sem g$ |
 | $f \alt g$ | $(\lambda t. t\, (\lambda \_\, \_. t)\, (\run\, \sem g\, v))\, (\run\, \sem f\, v \bind \trues)$ |
-| $f \as \$x | g$ | $\run\, \sem f\, v \bind (\lambda \$x. \run, \sem g\, v)$ |
-| $\try f \catch g$ | $\run\, \sem f\, v \bind_L \lambda r. r\, (\lambda o. \stream r)\, (\run\, \sem g)\, (\lambda b. \stream r)$ |
-| $\labelx x | f$ | $\labelf \fresh\, ((\lambda \$x\, \fresh. \run\, \sem f\, v)\, \fresh\, (\operatorname{succ}\, \fresh))$ |
-| $\breakx x$ | $\stream{\breakx x}$ |
-| $\ite{\$x}{f}{g}$ | $\run\, ((\bool\, \$x)\, \sem f\, \sem g)\, v$ |
+| $f \iras \$x | g$ | $\run\, \sem f\, v \bind (\lambda \$x. \run, \sem g\, v)$ |
+| $\irtc{f}{g}$ | $\run\, \sem f\, v \bind_L \lambda r. r\, (\lambda o. \stream r)\, (\run\, \sem g)\, (\lambda b. \stream r)$ |
+| $\irlb{label}{x} | f$ | $\labelf \fresh\, ((\lambda \$x\, \fresh. \run\, \sem f\, v)\, \fresh\, (\operatorname{succ}\, \fresh))$ |
+| $\irlb{break}{x}$ | $\stream{\irlb{break}{x}}$ |
+| $\irite{\$x}{f}{g}$ | $\run\, ((\bool\, \$x)\, \sem f\, \sem g)\, v$ |
 | $.[p]^?$ | $v[p]^?$ |
-| $\reduce f_x \as \$x (.; f)$ | $\reduce\, (\lambda \$x. \run\, \sem f)\, (\run\, \sem{f_x}\, v)\, v$ |
-| $\foreac f_x \as \$x (.; f; g)$ | $\foreac\, (\lambda \$x. \run\, \sem f)\, (\lambda \$x. \run\, \sem g)\, (\run\, \sem{f_x}\, v)\, v$ |
-| $\deff x(x_1; ...; x_n): f; g$ | $(\lambda x. \run\, \sem g\, v) (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
+| $\irfold{reduce }{f_x}{\$x}{(.; f   )}$ | $\reducef \, (\lambda \$x. \run\, \sem f)\, (\run\, \sem{f_x}\, v)\, v$ |
+| $\irfold{foreach}{f_x}{\$x}{(.; f; g)}$ | $\foreachf\, (\lambda \$x. \run\, \sem f)\, (\lambda \$x. \run\, \sem g)\, (\run\, \sem{f_x}\, v)\, v$ |
+| $\irdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \run\, \sem g\, v) (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
 | $x(f_1; ...; f_n)$ | $\run\, (x\, \sem{f_1}\, ...\, \sem{f_n})\, v$ |
 | $f \update g$ | $\upd\, \sem f\, (\run\, \sem g)\, v$ |
 
@@ -81,7 +85,7 @@ Let us discuss its different cases:
 - $\$x$: Returns the value currently bound to the variable $\$x$.
   Wellformedness of the filter (as defined in @sec:mir) ensures that
   whenever we evaluate $\$x$, it must have been substituted,
-  for example by a surrounding call to $f \as \$x | g$.
+  for example by a surrounding call to $f \iras \$x | g$.
 - $[]$ or $\{\}$: Creates an empty array or object.
 - $[f]$: Creates an array from the output of $f$, using the function $\arr$ defined in @sec:values.
 - $\{\$x: \$y\}$: Creates an object from the values bound to $\$x$ and $\$y$,
@@ -102,28 +106,28 @@ Let us discuss its different cases:
   Here, we use a function $\trues\, x$ that
   returns its input $x$ if its boolean value is true.
   $$\trues: \valt \to \listt \coloneq \lambda x. (\bool\, x)\, \stream{\ok\, x}\, \stream{}$$
-- $f \as \$x | g$: For every output of $f$, binds it to the variable $\$x$ and
+- $f \iras \$x | g$: For every output of $f$, binds it to the variable $\$x$ and
   returns the output of $g$, where $g$ may reference $\$x$.
   Unlike $f | g$, this runs $g$ with the original input value instead of an output of $f$.
   We can show that the evaluation of $f | g$ is equivalent to that of
-  $f \as \$x' | \$x' | g$, where $\$x'$ is a fresh variable.
+  $f \iras \$x' | \$x' | g$, where $\$x'$ is a fresh variable.
   Therefore, we could be tempted to lower $f | g$ to
-  $\floor f  \as \$x' | \$x' | \floor g$ in @tab:lowering,
+  $\floor f \iras \$x' | \$x' | \floor g$ in @tab:lowering,
   in order to further simplify IR and thus the semantics.
   However, we cannot do this because we will see in @sec:updates that
   this equivalence does _not_ hold for updates; that is,
   $(f | g) \update \sigma$ is _not_ equal to
-  $(f \as \$x' | \$x' | g) \update \sigma$.
-- $\try f \catch g$: Replaces all outputs of $f$ that equal $\err\, e$ for some $e$
+  $(f \iras \$x' | \$x' | g) \update \sigma$.
+- $\irtc{f}{g}$: Replaces all outputs of $f$ that equal $\err\, e$ for some $e$
   by the output of $g$ on the input $e$.
   At first sight, this seems to diverge from jq, which
   aborts the evaluation of $f$ after the first error.
   However, because lowering to IR replaces
   $\jqkw{try} f \jqkw{catch} g$ with
-  $\labelx{x'} | \try f \catch (g, \breakx{x'})$ (see @tab:lowering),
+  $\irlb{label}{x'} | \irtc{f}{(g, \irlb{break}{x'})}$ (see @tab:lowering),
   the overall behaviour described here corresponds to jq after all.
-- $\labelx x | f$: Returns all values yielded by $f$ until $f$ yields
-  an exception $\breakx{x}$.
+- $\irlb{label}{x} | f$: Returns all values yielded by $f$ until $f$ yields
+  an exception $\irlb{break}{x}$.
   This uses a function $\labelf$ that
   takes a label $\fresh$ and a list $l$ of value results,
   returning the longest prefix of $l$ that does not contain $\breakf\, \fresh$:
@@ -133,36 +137,36 @@ Let us discuss its different cases:
   \end{align*}
   In this function, $c$ gets bound to $\stream h  + \labelf\, \fresh\, t$,
   which is the function output when the head $h$ is not equal to $\labelf\, \fresh$.
-- $\breakx x$: Returns a value result $\breakx x$.
+- $\irlb{break}{x}$: Returns a value result $\irlb{break}{x}$.
   Similarly to the evaluation of variables $\$x$ described above,
   wellformedness of the filter (as defined in @sec:hir) ensures that
-  the returned value $\breakx x$ will be
+  the returned value $\irlb{break}{x}$ will be
   eventually handled by a corresponding filter
-  $\labelx x | f$.
+  $\irlb{label}{x} | f$.
   That means that $\eval \sem \varphi$ for a wellformed filter $\varphi$ can only yield
   values and errors, but never a break result.
-- $\ite{\$x}{f}{g}$: Returns the output of $f$ if $\$x$ is bound to
+- $\irite{\$x}{f}{g}$: Returns the output of $f$ if $\$x$ is bound to
   a "true" value (neither null nor false for JSON, see @sec:simple-fns), else returns the output of $g$.
 - $.[p]^?$: Accesses parts of the input value;
   see @sec:value-ops for the definitions of the operators.
   When evaluating this, the indices contained in $p$ have been substituted by values.
-- $\fold f_x \as \$x (.; f)$: Folds $f$ over the values returned by $f_x$,
+- $\irfold{\fold}{f_x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $f_x$,
   starting with the current input as accumulator.
   The current accumulator value is provided to $f$ as input value and
   $f$ can access the current value of $f_x$ by $\$x$.
-  If $\fold = \reduce$, this returns only the final        values of the accumulator, whereas
-  if $\fold = \foreac$, this returns also the intermediate values of the accumulator.
+  If $\fold =  \reducef$, this returns only the final        values of the accumulator, whereas
+  if $\fold = \foreachf$, this returns also the intermediate values of the accumulator.
   We will further explain this and define the functions
-  $\reduce  f\,     l\, v$ and
-  $\foreac f\, g\, l\, v$ in @sec:folding.
-- $\deff x(x_1; ...; x_n): f; g$: Binds the $n$-ary filter $x$ in $g$.
+  $\reducef  f\,     l\, v$ and
+  $\foreachf f\, g\, l\, v$ in @sec:folding.
+- $\irdef{x(x_1; ...; x_n)}{f} g$: Binds the $n$-ary filter $x$ in $g$.
   The definition of $x$, namely $f$, may refer to
   any of the arguments $x_i$ as well as to $x$ itself.
   In other words, filters can be defined recursively,
   which is why we use the Y combinator $Y_{n+1}$ here.
   @ex:recursion shows how a recursive call is evaluated.
 - $x(f_1; ...; f_n)$: Calls an $n$-ary filter $x$.
-  This also handles the case of calling nullary filters such as $\emptyf$.
+  This also handles the case of calling nullary filters such as $\irf{empty}$.
 - $f \update g$: Updates the input at positions returned by $f$ by $g$.
   We will discuss this in @sec:updates.
 
@@ -175,11 +179,11 @@ in particular because there is no simple way to obtain the domain of an object $
 using only the filters for which we gave semantics in @tab:eval-semantics.
 
 ::: {.example #ex:recursion name="Recursion"}
-  Consider the following IR filter $\varphi$: $$\deff \repeatf: ., \repeatf; \repeatf$$
+  Consider the following IR filter $\varphi$: $$\irdef{\irf{repeat}}{., \irf{repeat}} \irf{repeat}$$
   This filter repeatedly outputs its input;
   for example, given the input $v = 1$, it returns $\stream{\ok 1, \ok 1, \ok 1, ...}$.
   First, let us compile a part of our filter, namely
-  $$\rho = \sem{., \repeatf} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run \repeatf v)\, (...).$$
+  $$\rho = \sem{., \irf{repeat}} =^{\sem \cdot} \pair\, (\lambda v. \stream{\ok v} + \run \irf{repeat} v)\, (...).$$
   Here, the second part of the pair $(...)$ does not matter, because
   it is never evaluated due to our not performing any updates in this example.
 
@@ -190,13 +194,13 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
   $\eval\, \sem \varphi\, v$ is equivalent to:
   \begin{align*}
   \run\, \sem \varphi\, v
-  &= (\lambda \repeatf. \run\, \sem \repeatf\, v)\, (Y_1\, (\lambda \repeatf. \rho)) \\
-  &=^{\sem \cdot} (\lambda \repeatf. \run\, \repeatf\, v)\, (Y_1\, (\lambda \repeatf. \rho)) \\
-  &=^\beta \run\, (Y_1\, (\lambda \repeatf. \rho))\, v \\
-  &=^{Y_1} \run\, ((\lambda \repeatf. \rho)\, (Y_1\, (\lambda(\repeatf) \rho)))\, v \\
-  &=^\rho \run\, ((\lambda \repeatf. \pair\, (\lambda v. \stream{\ok v} + \run \repeatf v)\, (...))\, (Y_1\, (\lambda \repeatf. \rho)))\, v \\
-  &=^\beta \run\, (\pair\, (\lambda v. \stream{\ok v} + \run\, (Y_1\, (\lambda \repeatf. \rho))\, v)\, (...))\, v \\
-  &=^\beta \stream{\ok v} + \run\, (Y_1\, (\lambda \repeatf. \rho))\, v \\
+  &= (\lambda \irf{repeat}. \run\, \sem{\irf{repeat}}\, v)\, (Y_1\, (\lambda \irf{repeat}. \rho)) \\
+  &=^{\sem \cdot} (\lambda \irf{repeat}. \run\, \irf{repeat}\, v)\, (Y_1\, (\lambda \irf{repeat}. \rho)) \\
+  &=^\beta \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v \\
+  &=^{Y_1} \run\, ((\lambda \irf{repeat}. \rho)\, (Y_1\, (\lambda \irf{repeat}. \rho)))\, v \\
+  &=^\rho \run\, ((\lambda \irf{repeat}. \pair\, (\lambda v. \stream{\ok v} + \run\, \irf{repeat}\, v)\, (...))\, (Y_1\, (\lambda \irf{repeat}. \rho)))\, v \\
+  &=^\beta \run\, (\pair\, (\lambda v. \stream{\ok v} + \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v)\, (...))\, v \\
+  &=^\beta \stream{\ok v} + \run\, (Y_1\, (\lambda \irf{repeat}. \rho))\, v \\
   &= \stream{\ok v} + \run\, \sem \varphi\, v.
   \end{align*}
   This shows that the evaluation of $\varphi$ on any input $v$ yields
@@ -204,38 +208,32 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
 :::
 
 ::: {.example #ex:labels name="Labels"}
-  Let us consider the filter $\varphi \equiv \labelx x | \breakx x$.
+  Let us consider the filter $\varphi \equiv \irlb{label}{x} | \irlb{break}{x}$.
   We have:
   \begin{align*}
   \eval\, \sem \varphi\, v
-  &= (\lambda \fresh. \run \sem{\labelx x | \breakx x})\, \zero\, v \\
-  &= (\lambda \fresh\, v. \labelf\, \fresh\, ((\lambda \$x\, \fresh. \run\, \sem{\breakx x}\, v)\, \fresh\, (\succf\, \fresh)))\, \zero\, v \\
-  &= \labelf\, \zero\, ((\lambda \$x\, \fresh. \stream{\breakx x})\, \zero\, (\succf\, \zero)) \\
+  &= (\lambda \fresh. \run \sem{\irlb{label}{x} | \irlb{break}{x}})\, \zero\, v \\
+  &= (\lambda \fresh\, v. \labelf\, \fresh\, ((\lambda \$x\, \fresh. \run\, \sem{\irlb{break}{x}}\, v)\, \fresh\, (\succf\, \fresh)))\, \zero\, v \\
+  &= \labelf\, \zero\, ((\lambda \$x\, \fresh. \stream{\irlb{break}{x}})\, \zero\, (\succf\, \zero)) \\
   &= \labelf\, \zero\, \stream{\breakf \zero} \\
   &= \stream{}
   \end{align*}
-  It is interesting to note that if instead of $\breakx x$,
-  we would have used a more complex filter, e.g. $\labelx y | ...$,
+  It is interesting to note that if instead of $\irlb{break}{x}$,
+  we would have used a more complex filter, e.g. $\irlb{label}{y} | ...$,
   then $\$y$ would have been substituted by $\succf\, \zero$
   (which we can already see in our large equation above).
   This mechanism reliably allows us to generate fresh labels and to
   differentiate for each $\breakf$ the corresponding $\labelf$ that handles it.
 :::
 
-<!--
-For $"length"$, we could give a definition, using
-$"reduce" .[] \as \$x (0; . + 1)$ to obtain the length of arrays and objects, but
-this would inherently require linear time to yield a result, instead of
-constant time that can be achieved by a proper jq implementation.
--->
-
 ## Folding {#sec:folding}
 
 In this subsection, we will define the functions
-$\reduce$ and $\foreac$ which underlie the semantics for the folding operators
-$\reduce  f_x \as \$x (.; f)$ and
-$\foreac f_x \as \$x (.; f; g)$.
+$\reducef$ and $\foreachf$ which underlie the semantics for the folding operators
+$\irfold{reduce }{f_x}{\$x}{(.; f)}$ and
+$\irfold{foreach}{f_x}{\$x}{(.; f; g)}$.
 
+\newcommand{\foldf}{\operatorname{fold}}
 Let us start by defining a general folding function $\foldf$:
 \begin{align*}
 \foldf&: (\valt \to \valt \to \listt) \to (\valt \to \valt \to \listt) \to (\valt \to \listt) \to \listt \to \valt \to \listt \\
@@ -255,38 +253,38 @@ used as new accumulator value with the remaining list $t$.
 If $l$ is empty, then $v$ is called a _final_ accumulator value and $n\, v$ is returned.
 
 We use two different functions for $n$;
-the first returns just its input, corresponding to $\reduce$ which returns a final value, and
-the second returns nothing,  corresponding to $\foreac$.
+the first returns just its input, corresponding to $\reducef$ which returns a final value, and
+the second returns nothing,  corresponding to $\foreachf$.
 Instantiating $\foldf$ with these two functions, we obtain the following:
 \begin{alignat*}{4}
-\reduce &\coloneq \lambda f.     && \foldf\, f\, (\lambda h\, v. \stream{})\, && (\lambda v. \stream{\ok v &&}) \\
-\foreac &\coloneq \lambda f\, g. && \foldf\, f\, g\, && (\lambda v. \stream{&&})
+\reducef &\coloneq \lambda f.     && \foldf\, f\, (\lambda h\, v. \stream{})\, && (\lambda v. \stream{\ok v &&}) \\
+\foreachf &\coloneq \lambda f\, g. && \foldf\, f\, g\, && (\lambda v. \stream{&&})
 \end{alignat*}
-Here, $\reduce$ and $\foreac$ are the functions used in @tab:eval-semantics.
+Here, $\reducef$ and $\foreachf$ are the functions used in @tab:eval-semantics.
 Their types are:
 \begin{alignat*}{2}
-\reduce &: (\valt \to \valt \to \listt)                                  &&\to \listt \to \valt \to \listt \\
-\foreac&: (\valt \to \valt \to \listt) \to (\valt \to \valt \to \listt) &&\to \listt \to \valt \to \listt
+\reducef &: (\valt \to \valt \to \listt)                                  &&\to \listt \to \valt \to \listt \\
+\foreachf&: (\valt \to \valt \to \listt) \to (\valt \to \valt \to \listt) &&\to \listt \to \valt \to \listt
 \end{alignat*}
 We will now look at what the evaluation of the various folding filters expands to.
 Assuming that the filter $f_x$ evaluates to $\stream{x_0, ..., x_n}$,
-then $\reduce$ and $\foreac$ expand to
+then $\reducef$ and $\foreachf$ expand to
 \begin{alignat*}{2}
-\reduce   f_x \as \$x (.; f   ) ={}& x_0 \as \$x | f & \quad
-\foreac  f_x \as \$x (.; f; g) ={}& x_0 \as \$x | f | g, ( \\
+\irfold{reduce }{f_x}{\$x}{(.; f   )} ={}& x_0 \iras \$x | f & \quad
+\irfold{foreach}{f_x}{\$x}{(.; f; g)} ={}& x_0 \iras \$x | f | g, ( \\
 |\; & ... &
     & ... \\
-|\; & x_n \as \$x | f &
-    & x_n \as \$x | f | g, ( \\
+|\; & x_n \iras \$x | f &
+    & x_n \iras \$x | f | g, ( \\
     &     &
-    & \emptyf)...)
+    & \irf{empty})...)
 \end{alignat*}
 Note that jq implements only restricted versions of these folding operators
 that consider only the last output of $f$ for the next iteration.
 That means that in jq,
-$\reduce f_x \as \$x (.;       f)$ is equivalent to
-$\reduce f_x \as \$x (.; \last(f))$.
-Here, we assume that the filter $\last(f)$
+$\irfold{reduce}{f_x}{\$x}{(.;            f )}$ is equivalent to
+$\irfold{reduce}{f_x}{\$x}{(.; \irf{last}(f))}$.
+Here, we assume that the filter $\irf{last}(f)$
 returns the last output of $f$ if $f$ yields any output, else nothing.
 
 
@@ -389,17 +387,17 @@ Table: Update semantics properties. {#tab:update-props}
 
 | $\varphi$ | $\varphi \update \sigma$ |
 | --------- | ------------------------ |
-| $\emptyf$ | $.$ |
+| $\irf{empty}$ | $.$ |
 | $.$ | $\sigma$ |
 | $f | g$ | $f \update (g \update \sigma)$ |
 | $f, g$ | $(f \update \sigma) | (g \update \sigma)$ |
-| $\ite{\$x}{f}{g}$ | $\ite{\$x}{f \update \sigma}{g \update \sigma}$ |
-| $f \alt g$ | $\ite{\first(f \alt \nullf)}{f \update \sigma}{g \update \sigma}$ |
+| $\irite{\$x}{f}{g}$ | $\irite{\$x}{f \update \sigma}{g \update \sigma}$ |
+| $f \alt g$ | $\irite{\irf{first}(f \alt \nullf)}{f \update \sigma}{g \update \sigma}$ |
 
 @tab:update-props gives a few properties that we want to hold for updates $\varphi \update \sigma$.
 Let us discuss these for the different filters $\varphi$:
 
-- $\emptyf$: Returns the input unchanged.
+- $\irf{empty}$: Returns the input unchanged.
 - "$.$": Returns the output of the update filter $\sigma$ applied to the current input.
   Note that while jq only returns at most one output of $\sigma$,
   these semantics return an arbitrary number of outputs.
@@ -409,9 +407,9 @@ Let us discuss these for the different filters $\varphi$:
   $.[] \update (.[] \update \sigma)$, yielding the same output as in the example.
 - $f, g$: Applies the update of $\sigma$ at $g$ to the output of the update of $\sigma$ at $f$.
   We have already seen this at the end of @sec:jq-updates.
-- $\ite{\$x}{f}{g}$: Applies $\sigma$ at $f$ if $\$x$ holds, else at $g$.
+- $\irite{\$x}{f}{g}$: Applies $\sigma$ at $f$ if $\$x$ holds, else at $g$.
 - $f \alt g$: Applies $\sigma$ at $f$ if $f$ yields some output whose boolean value (see @sec:simple-fns) is not false, else applies $\sigma$ at $g$.
-  Here, $\first(f)$ is a filter that returns
+  Here, $\irf{first}(f)$ is a filter that returns
   the first output of its argument $f$ if there is one, else the empty list.
 
 While @tab:update-props allows us to define the behaviour of several filters
@@ -427,19 +425,19 @@ To define $\upd\, \sem \varphi\, \sigma\, v$, we first have to understand
 how to prevent unwanted interactions between $\varphi$ and $\sigma$.
 In particular, we have to look at variable bindings.
 
-We can bind variables in $\varphi$; that is, $\varphi$ can have the shape $f \as \$x | g$.
+We can bind variables in $\varphi$; that is, $\varphi$ can have the shape $f \iras \$x | g$.
 Here, the intent is that $g$ has access to $\$x$, whereas $\sigma$ does not!
 This is to ensure compatibility with jq's original semantics,
 which execute $\varphi$ and $\sigma$ independently,
 so $\sigma$ should not be able to access variables bound in $\varphi$.
 
 ::: {.example}
-  Consider the filter $0 \as \$x | \varphi \update \sigma$, where
-  $\varphi$ is $(1 \as \$x | .[\$x])$ and $\sigma$ is $\$x$.
+  Consider the filter $0 \iras \$x | \varphi \update \sigma$, where
+  $\varphi$ is $(1 \iras \$x | .[\$x])$ and $\sigma$ is $\$x$.
   This updates the input array at index $1$.
   If $\sigma$ had access to variables bound in $\varphi$,
   then the array element would be replaced by $1$,
-  because the variable binding $0 \as \$x$ would be shadowed by $1 \as \$x$.
+  because the variable binding $0 \iras \$x$ would be shadowed by $1 \iras \$x$.
   However, in jq, $\sigma$ does not have access to variables bound in $\varphi$, so
   the array element is replaced by $0$, which is the value originally bound to $\$x$.
   Given the input array $[1, 2, 3]$, the filter yields the final result $[1, 0, 3]$.
@@ -472,19 +470,19 @@ Table: Update semantics. Here, $\varphi$ is a filter and $\sigma: \valt \to \lis
 | $.$ | $\sigma\, v$ |
 | $f | g$ | $\upd\, \sem f\, (\upd\, \sem g\, \sigma)\, v$ |
 | $f, g$ | $\upd\, \sem f\, \sigma\, v \bind \upd\, \sem g\, \sigma$ |
-| $f \alt g$ | $\upd\, ((\run\, \sem f\, v \bind \trues)\, (\lambda(\_, \_) \sem f)\, \sem g)\, \sigma\, v$ |
+| $f \alt g$ | $\upd\, ((\run\, \sem f\, v \bind \trues)\, (\lambda \_\, \_. \sem f)\, \sem g)\, \sigma\, v$ |
 | $.[p]^?$ | $\stream{v[p]^? \update \sigma}$ |
-| $f \as \$x | g$ | $\reduce\, (\lambda \$x. \upd\, \sem g\, \sigma)\, (\run\, \sem f\, v)\, v$ |
-| $\ite{\$x}{f}{g}$ | $\upd\, ((\bool\, \$x)\, \sem f\, \sem g)\, \sigma\, v$ |
-| $\breakx x$ | $\stream{\breakx x}$ |
-| $\reduce x \as \$x (.; f)$ | $\reduce_{\update}\, (\lambda(\$x). \upd\, \sem f)\, \sigma\, (\run\, \sem x\, v)\, v$ |
-| $\foreac x \as \$x (.; f; g)$ | $\foreac_{\update}\, (\lambda \$x. \upd\, \sem f)\, (\lambda \$x. \upd\, \sem g)\, \sigma\, (\run\, \sem x\, v)\, v$ |
-| $\deff x(x_1; ...; x_n): f; g$ | $(\lambda x. \upd\, \sem g\, \sigma\, v)\, (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
+| $f \iras \$x | g$ | $\reducef\, (\lambda \$x. \upd\, \sem g\, \sigma)\, (\run\, \sem f\, v)\, v$ |
+| $\irite{\$x}{f}{g}$ | $\upd\, ((\bool\, \$x)\, \sem f\, \sem g)\, \sigma\, v$ |
+| $\irlb{break}{x}$ | $\stream{\irlb{break}{x}}$ |
+| $\irfold{reduce}{x}{\$x}{(.; f)}$ | $\reducef_{\update}\, (\lambda \$x. \upd\, \sem f)\, \sigma\, (\run\, \sem x\, v)\, v$ |
+| $\irfold{foreach}{x}{\$x}{(.; f; g)}$ | $\foreachf_{\update}\, (\lambda \$x. \upd\, \sem f)\, (\lambda \$x. \upd\, \sem g)\, \sigma\, (\run\, \sem x\, v)\, v$ |
+| $\irdef{x(x_1; ...; x_n)}{f} g$ | $(\lambda x. \upd\, \sem g\, \sigma\, v)\, (Y_{n+1}\, (\lambda x\, x_1\, ...\, x_n. \sem f))$ |
 | $x(f_1; ...; f_n)$ | $\upd\, (x\, \sem{f_1}\, ...\, \sem{f_n})\, \sigma\, v$ |
 
 @tab:update-semantics shows the definition of $\upd\, \sem \varphi\, \sigma\, v$.
 Several of the cases for $\varphi$, like
-"$.$", "$f | g$", "$f, g$", and "$\ite{\$x}{f}{g}$"
+"$.$", "$f | g$", "$f, g$", and "$\irite{\$x}{f}{g}$"
 are simply relatively straightforward consequences of the properties in @tab:update-props.
 We discuss the remaining cases for $\varphi$:
 
@@ -498,25 +496,25 @@ We discuss the remaining cases for $\varphi$:
   updated with ($\upd\, \sem f\, \sigma\, v$).
 - $.[p]^?$: Applies $\sigma$ to the current value at the path part $p$
   using the update operators in @sec:value-ops.
-- $f \as \$x | g$:
+- $f \iras \$x | g$:
   Folds over all outputs of $f$, using the input value $v$ as initial accumulator and
   updating the accumulator by $g \update \sigma$, where
   $\$x$ is bound to the current output of $f$.
-  The definition of $\reduce$ is given in @sec:folding.
-- $\fold x \as \$x (.; f)$: Folds $f$ over the values returned by $\$x$.
+  The definition of $\reducef$ is given in @sec:folding.
+- $\irfold{\fold}{x}{\$x}{(.; f)}$: Folds $f$ over the values returned by $\$x$.
   We will discuss this in @sec:folding-update.
-- $\deff x(x_1; ...; x_n): f; g$: Defines a filter.
+- $\irdef{x(x_1; ...; x_n)}{f} g$: Defines a filter.
   This is defined analogously to @tab:eval-semantics.
 - $x(f_1; ...; f_n)$, $x$: Calls a filter.
   This is defined analogously to @tab:eval-semantics.
 
 There are many filters $\varphi$ for which
 $\upd\, \sem \varphi\, \sigma\, v$ is not defined,
-for example $\$x$, $[f]$, and $\obj{}$.
+for example $\$x$, $[f]$, and $\{\}$.
 In such cases, we assume that $\upd\, \sem \varphi\, \sigma\, v$ returns an error just like jq,
 because these filters do not return paths to their input data.
 Our update semantics support all kinds of filters $\varphi$ that are supported by jq, except for
-$\labelx x | g$ and $\try f \catch g$.
+$\irlb{label}{x} | g$ and $\irtc{f}{g}$.
 
 ::: {.example name="Update compilation"}
   Let us consider the jq filter `(.[] |= .+.)`.
@@ -526,8 +524,8 @@ $\labelx x | g$ and $\try f \catch g$.
   effectively doubling its input.
   For example, when given the input $[1, 2, 3]$, the output of $\varphi$ is $[2, 4, 6]$.
   Before we can execute the jq filter, we have to lower it to IR, e.g. to
-  $\varphi \equiv (.[] \update (. \as \$x | \$x + \$x))$.^[
-    Note that the actual lowering $(.[] \update (. \as \$x | . \as \$y | \$x + \$y))$
+  $\varphi \equiv (.[] \update (. \iras \$x | \$x + \$x))$.^[
+    Note that the actual lowering $(.[] \update (. \iras \$x | . \iras \$y | \$x + \$y))$
     is a bit longer than the $\varphi$ given here, but
     because the two are semantically equivalent, we continue with $\varphi$.
   ]
@@ -535,10 +533,10 @@ $\labelx x | g$ and $\try f \catch g$.
   $\eval\, \sem \varphi\, v = (\lambda \fresh. \run\, \sem \varphi)\, \zero\, v$.
   Because $\varphi$ does not use any labels,
   this is equivalent to just $\run\, \sem \varphi\, v = \upd\, \sem{(.[])}\, \sigma\, v = (v[] \update \sigma)$.
-  Here, we introduced $\sigma \equiv \run\, \sem{. \as \$x | \$x + \$x}$.
+  Here, we introduced $\sigma \equiv \run\, \sem{. \iras \$x | \$x + \$x}$.
   We can further expand $\sigma$:
   \begin{align*} \sigma
-  &= \lambda v. \run\, \sem{. \as \$x | \$x + \$x}\, v \\
+  &= \lambda v. \run\, \sem{. \iras \$x | \$x + \$x}\, v \\
   &= \lambda v. \run\, \sem{.} \bind (\lambda \$x. \run\, \sem{\$x + \$x}\, v) \\
   &= \lambda v. \stream{\ok v} \bind (\lambda \$x. \stream{\$x + \$x}) \\
   &= \lambda v. \stream(v + v)
@@ -579,17 +577,17 @@ $\labelx x | g$ and $\try f \catch g$.
 
   Finally, on the input
   $[]$, the filter
-  $(.[] \alt \error) \update 1$ yields
+  $(.[] \alt \irf{error}) \update 1$ yields
   $\stream{\err\, []}$.
   That is because $.[]$ does not yield any value for the input,
-  so ${\error} \update 1$ is executed, which yields an error.
+  so $\irf{error} \update 1$ is executed, which yields an error.
 :::
 
 ## Folding {#sec:folding-update}
 
 In @sec:folding, we have seen how to evaluate folding filters of the shape
-$\reduce x \as \$x (.; f)$ and
-$\foreac x \as \$x (.; f; g)$.
+$\irfold{reduce }{x}{\$x}{(.; f)}$ and
+$\irfold{foreach}{x}{\$x}{(.; f; g)}$.
 Here, we will define update semantics for these filters.
 These update operations are _not_ supported in jq 1.7; however,
 we will show that they arise quite naturally from previous definitions.
@@ -598,19 +596,19 @@ Let us start with an example to understand folding on the left-hand side of an u
 
 ::: {.example #ex:folding-update}
   Let $v = [[[2], 1], 0]$ be our input value
-  and $\varphi$ be the filter $\fold (0, 0) \as \$x (.; .[\$x])$.
+  and $\varphi$ be the filter $\irfold{\fold}{(0, 0)}{\$x}{(.; .[\$x])}$.
   The regular evaluation of $\varphi$ with the input value as described in @sec:semantics yields
   $$\run\, \sem \varphi\, v = \begin{cases}
-    \stream{\phantom{[[2], 1],\,} [2]} & \text{if } \fold = {\reduce} \\
-    \stream{         [[2], 1],    [2]} & \text{if } \fold = {\foreac}
+    \stream{\phantom{[[2], 1],\,} [2]} & \text{if } \fold = \reducef \\
+    \stream{         [[2], 1],    [2]} & \text{if } \fold = \foreachf
   \end{cases}$$
-  When $\fold = {\foreac}$, the paths corresponding to the output are $.[0]$ and $.[0][0]$, and
-  when $\fold = {\reduce}$, the paths are just $.[0][0]$.
+  When $\fold = {\foreachf}$, the paths corresponding to the output are $.[0]$ and $.[0][0]$, and
+  when $\fold = {\reducef}$, the paths are just $.[0][0]$.
   Given that all outputs have corresponding paths, we can update over them.
   For example, taking $. + [3]$ as filter $\sigma$, we should obtain the output
   $$\upd\, \sem \varphi\, (\run\, \sem \sigma)\, v = \begin{cases}
-    \stream{[[[2, 3], 1\phantom{, 3}], 0]} & \text{if } \fold = {\reduce} \\
-    \stream{[[[2, 3], 1         , 3 ], 0]} & \text{if } \fold = {\foreac}
+    \stream{[[[2, 3], 1\phantom{, 3}], 0]} & \text{if } \fold = \reducef \\
+    \stream{[[[2, 3], 1         , 3 ], 0]} & \text{if } \fold = \foreachf
   \end{cases}$$
 :::
 
@@ -619,43 +617,43 @@ the lowering in @tab:lowering and
 the defining equations in @sec:folding
 only make use of filters for which we have already introduced update semantics in @tab:update-semantics.
 This should not be taken for granted; for example, we originally lowered
-$\fold f_x \as \$x (f_y; f)$ to
-$$\floor{f_y} \as \$y | \fold \floor{f_x} \as \$x (\$y; \floor{f})$$
+$\irfold{\fold}{f_x}{\$x}{(f_y; f)}$ to
+$$\floor{f_y} \iras \$y | \irfold{\fold}{\floor{f_x}}{\$x}{(\$y; \floor{f})}$$
 instead of the more complicated lowering found in @tab:lowering, namely
-$$. \as \$x' | \floor{f_y} | \fold \floor{\$x' | f_x} \as \$x (.; \floor{f}).$$
+$$. \iras \$x' | \floor{f_y} | \irfold{\fold}{\floor{\$x' | f_x}}{\$x}{(.; \floor{f})}.$$
 While both lowerings produce the same output for regular evaluation,
 we cannot use the original lowering for updates, because the defining equations for
-$\fold x \as \$x (\$y; f)$ would have the shape $\$y | ...$,
+$\irfold{\fold}{x}{\$x}{(\$y; f)}$ would have the shape $\$y | ...$,
 which is undefined on the left-hand side of an update.
 However, the lowering in @tab:lowering avoids this issue
 by not binding the output of $f_y$ to a variable,
 so it can be used on the left-hand side of updates.
 
 To obtain an intuition about how the update evaluation of a fold looks like, we can take
-$\fold x \as \$x (.; f; g) \update \sigma$,
+$\irfold{\fold}{x}{\$x}{(.; f; g)} \update \sigma$,
 substitute the left-hand side by the defining equations in @sec:folding and
 expand everything using the properties in @sec:update-props.
 This yields
 \begin{alignat*}{2}
-\reduce  x \as \$x (.; f   ) \update \sigma
-={}& x_0 \as \$x | (f \update ( \\
+\irfold{reduce}{x}{\$x}{(.; f   )} \update \sigma
+={}& x_0 \iras \$x | (f \update ( \\
  & ... \\
- & x_n \as \$x | (f \update (  \\
+ & x_n \iras \$x | (f \update (  \\
  & \sigma))...)) \\
-\foreac x \as \$x (.; f; g) \update \sigma
-={}& x_0 \as \$x | (f \update ((g \update \sigma) | \\
+\irfold{foreach}{x}{\$x}{(.; f; g)} \update \sigma
+={}& x_0 \iras \$x | (f \update ((g \update \sigma) | \\
  & ... \\
- & x_n \as \$x | (f \update ((g \update \sigma) | \\
+ & x_n \iras \$x | (f \update ((g \update \sigma) | \\
  & .))...)).
 \end{alignat*}
 
 ::: {.example}
   To see the effect of above equations, let us reconsider
   the input value and the filters from @ex:folding-update.
-  Using some liberty to write $.[0]$ instead of $0 \as \$x | .[\$x]$, we have:
+  Using some liberty to write $.[0]$ instead of $0 \iras \$x | .[\$x]$, we have:
   $$\varphi \update \sigma = \begin{cases}
-    .[0] \update \phantom{\sigma | (}.[0] \update \sigma   & \text{if } \fold = {\reduce} \\
-    .[0] \update          \sigma | ( .[0] \update \sigma)  & \text{if } \fold = {\foreac}
+    .[0] \update \phantom{\sigma | (}.[0] \update \sigma   & \text{if } \fold = \reducef \\
+    .[0] \update          \sigma | ( .[0] \update \sigma)  & \text{if } \fold = \foreachf
   \end{cases}$$
 :::
 
@@ -669,11 +667,11 @@ Its first argument is of type $\valt \to (\valt \to \listt) \to \valt \to \listt
 \end{align*}
 Using this function, we can now define
 \begin{alignat*}{4}
-\reduce_{\update} &\coloneq \lambda f\,      &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. \stream{\ok v})\, && \sigma \\
-\foreac_{\update} &\coloneq \lambda f\, g\, &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. g\, h\, \sigma\, v)\, && (\lambda v. \stream{\ok v})
+\reducef _{\update} &\coloneq \lambda f\,     &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. \stream{\ok v})\, && \sigma \\
+\foreachf_{\update} &\coloneq \lambda f\, g\, &&\sigma. \foldf_{\update}\, f\, (\lambda h\, v. g\, h\, \sigma\, v)\, && (\lambda v. \stream{\ok v})
 \end{alignat*}
 The types of the functions are:
 \begin{alignat*}{2}
-\reduce_{\update}&: \mathcal U                &&\to (\valt \to \listt) \to \listt \to \valt \to \listt \\
-\foreac_{\update}&: \mathcal U \to \mathcal U &&\to (\valt \to \listt) \to \listt \to \valt \to \listt
+\reducef _{\update}&: \mathcal U                &&\to (\valt \to \listt) \to \listt \to \valt \to \listt \\
+\foreachf_{\update}&: \mathcal U \to \mathcal U &&\to (\valt \to \listt) \to \listt \to \valt \to \listt
 \end{alignat*}

--- a/semantics.md
+++ b/semantics.md
@@ -68,7 +68,7 @@ Table: Evaluation semantics. {#tab:eval-semantics}
 | $f \jqas \$x | g$ | $\run\, \sem f\, v \bind (\lambda \$x. \run, \sem g\, v)$ |
 | $\jqtc{f}{g}$ | $\run\, \sem f\, v \bind_L \lambda r. r\, (\lambda o. \stream r)\, (\run\, \sem g)\, (\lambda b. \stream r)$ |
 | $\jqlb{label}{x} | f$ | $\labelf \fresh\, ((\lambda \$x\, \fresh. \run\, \sem f\, v)\, \fresh\, (\operatorname{succ}\, \fresh))$ |
-| $\jqlb{break}{x}$ | $\stream{\jqlb{break}{x}}$ |
+| $\jqlb{break}{x}$ | $\stream{\breakf\, \$x}$ |
 | $\jqite{\$x}{f}{g}$ | $\run\, ((\bool\, \$x)\, \sem f\, \sem g)\, v$ |
 | $.[p]^?$ | $v[p]^?$ |
 | $\jqfold{reduce }{f_x}{\$x}{(.; f   )}$ | $\reducef \, (\lambda \$x. \run\, \sem f)\, (\run\, \sem{f_x}\, v)\, v$ |
@@ -127,7 +127,7 @@ Let us discuss its different cases:
   $\jqlb{label}{x'} | \jqtc{f}{(g, \jqlb{break}{x'})}$ (see @tab:lowering),
   the overall behaviour described here corresponds to jq after all.
 - $\jqlb{label}{x} | f$: Returns all values yielded by $f$ until $f$ yields
-  an exception $\jqlb{break}{x}$.
+  an exception $\breakf\, \$x$.
   This uses a function $\labelf$ that
   takes a label $\fresh$ and a list $l$ of value results,
   returning the longest prefix of $l$ that does not contain $\breakf\, \fresh$:
@@ -137,10 +137,10 @@ Let us discuss its different cases:
   \end{align*}
   In this function, $c$ gets bound to $\stream h  + \labelf\, \fresh\, t$,
   which is the function output when the head $h$ is not equal to $\labelf\, \fresh$.
-- $\jqlb{break}{x}$: Returns a value result $\jqlb{break}{x}$.
+- $\jqlb{break}{x}$: Returns a value result $\breakf\, \$x$.
   Similarly to the evaluation of variables $\$x$ described above,
   wellformedness of the filter (as defined in @sec:hir) ensures that
-  the returned value $\jqlb{break}{x}$ will be
+  the returned value $\breakf\, \$x$ will be
   eventually handled by a corresponding filter
   $\jqlb{label}{x} | f$.
   That means that $\eval \sem \varphi$ for a wellformed filter $\varphi$ can only yield
@@ -215,7 +215,7 @@ using only the filters for which we gave semantics in @tab:eval-semantics.
   &= (\lambda \fresh. \run \sem{\jqlb{label}{x} | \jqlb{break}{x}})\, \zero\, v \\
   &= (\lambda \fresh\, v. \labelf\, \fresh\, ((\lambda \$x\, \fresh. \run\, \sem{\jqlb{break}{x}}\, v)\, \fresh\, (\succf\, \fresh)))\, \zero\, v \\
   &= \labelf\, \zero\, ((\lambda \$x\, \fresh. \stream{\jqlb{break}{x}})\, \zero\, (\succf\, \zero)) \\
-  &= \labelf\, \zero\, \stream{\breakf \zero} \\
+  &= \labelf\, \zero\, \stream{\breakf\, \zero} \\
   &= \stream{}
   \end{align*}
   It is interesting to note that if instead of $\jqlb{break}{x}$,

--- a/structure.dot
+++ b/structure.dot
@@ -13,8 +13,7 @@ digraph {
   node [shape=box margin=0.1 width=0 height=0]
   subgraph cluster_syntax {
     label="Syntax"
-    hir [label="HIR"]
-    mir [label="MIR"]
+    ir [label="IR"]
   }
   subgraph cluster_semantics {
     label = "Semantics"
@@ -23,9 +22,8 @@ digraph {
   }
 
   edge [arrowsize=0.5]
-  program -> hir
-  hir -> mir
-  mir -> eval
+  program -> ir
+  ir -> eval
   input -> above_eval [arrowhead=none]
   above_eval -> eval [tailport=center]
   eval -> output

--- a/syntax.md
+++ b/syntax.md
@@ -21,10 +21,10 @@ We will now present a subset of jq syntax^[
 
 \newcommand{\jqkw}[1]{\mathrel{\operatorname{\mathtt{#1}}}}
 \newcommand{\jqas}{\jqkw{as}}
-\newcommand{\jqdef}[3]{{\jqkw{def} #1\!: #2;\; #3}}
-\newcommand{\jqite}[3]{{\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}}
-\newcommand{\jqfold}[4]{{\jqkw{#1} #2 \jqas #3\; #4}}
-\newcommand{\jqlb}[2]{{\jqkw{#1}\, \$#2}}
+\newcommand{\jqdef }[3]{\relrel\jqkw{def} #1\!: #2;\; #3}
+\newcommand{\jqite }[3]{\relrel\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
+\newcommand{\jqfold}[4]{\relrel\jqkw{#1} #2 \jqas #3\; #4}
+\newcommand{\jqlb  }[2]{\relrel\jqkw{#1}\, \$#2}
 
 A _filter_ $f$ is defined by the grammar
 \begin{align*}

--- a/syntax.md
+++ b/syntax.md
@@ -17,7 +17,7 @@ We will now present a subset of jq syntax^[
 
 A _filter_ $f$ is defined by the grammar
 \begin{align*}
-f &\coloneq \quad n \gror s \gror . \gror .. \\
+f &\coloneqq \quad n \gror s \gror . \gror .. \\
   &\gror (f) \gror f? \gror [] \gror [f] \gror \{f: f, \dots, f: f\} \gror f [p]^? \dots [p]^? \\
   &\gror f \star f \gror f \cartesian f \\
   &\gror f \jqas P | f \gror \jqfold{reduce}{f}{P}{(f; f)} \gror \jqfold{foreach}{f}{P}{(f; f; f)} \gror \$x \\
@@ -28,8 +28,8 @@ f &\coloneq \quad n \gror s \gror . \gror .. \\
 \end{align*}
 where:
 
-- $p$ is a _path part_ defined by the grammar $p \coloneq \quad \emptyset \gror f \gror f: \gror :f \gror f:f$.
-- $P$ is a _pattern_ defined by the grammar $P \coloneq \quad \$x \gror [P, \dots, P] \gror \{f: P, \dots, f: P\}$.
+- $p$ is a _path part_ defined by the grammar $p \coloneqq \quad \emptyset \gror f \gror f: \gror :f \gror f:f$.
+- $P$ is a _pattern_ defined by the grammar $P \coloneqq \quad \$x \gror [P, \dots, P] \gror \{f: P, \dots, f: P\}$.
 - $x$ is an identifier (such as $\jqf{empty}$).
 - $n$ is a number (such as $42$ or $3.14$).
 - $s$ is a string (such as "Hello world!").
@@ -85,7 +85,7 @@ in a much less verbose way than for actual jq syntax.
 
 An IR filter $f$ is defined by the grammar
 \begin{align*}
-f &\coloneq \quad n \gror s \gror . \\
+f &\coloneqq \quad n \gror s \gror . \\
   &\gror [] \gror [f] \gror {} \gror \{\$x: \$x\} \gror .[p] \\
   &\gror f \star f \gror \$x \cartesian \$x \\
   &\gror f \jqas \$x | f \gror \jqfold{reduce}{f}{\$x}{(.; f)} \gror \jqfold{foreach}{f}{\$x}{(.; f; f)} \gror \$x \\
@@ -164,10 +164,10 @@ $\floor{f \star g} = \floor f \star \floor g$.
 
 We define filters that yield the boolean values as
 \begin{align*}
-\jqf{true}  &\coloneq (0 \iseq 0), \\
-\jqf{false} &\coloneq (0  \neq 0).
+\jqf{true}  &\coloneqq (0 \iseq 0), \\
+\jqf{false} &\coloneqq (0  \neq 0).
 \end{align*}
-The filter "$\jqf{bool} \coloneq (\jqite{.}{\true}{\false})$"
+The filter "$\jqf{bool} \coloneqq (\jqite{.}{\true}{\false})$"
 maps its input to its boolean value.
 
 In the lowering of the folding operators $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$

--- a/syntax.md
+++ b/syntax.md
@@ -30,9 +30,9 @@ where:
 
 - $p$ is a _path part_ defined by the grammar $p \coloneq \quad \emptyset \gror f \gror f: \gror :f \gror f:f$.
 - $P$ is a _pattern_ defined by the grammar $P \coloneq \quad \$x \gror [P, \dots, P] \gror \{f: P, \dots, f: P\}$.
-- $x$ is an identifier (such as `empty`).
-- $n$ is a number (such as `42` or `3.14`).
-- $s$ is a string (such as `"Hello world!"`).
+- $x$ is an identifier (such as $\jqf{empty}$).
+- $n$ is a number (such as $42$ or $3.14$).
+- $s$ is a string (such as "Hello world!").
 
 We use the superscript "$?$" to denote an optional presence of "?"; in particular,
 $f [p]^? \dots [p]^?$ can be

--- a/syntax.md
+++ b/syntax.md
@@ -230,9 +230,9 @@ Semantically, we will see that this is equivalent to $(.[]? | .[])$.
 The jq filter $\mu \equiv .[0]$ is lowered to
 $\floor \mu \equiv . \jqas \$x | . | (\$x | 0) \jqas \$y | .[\$y]$.
 Semantically, we will see that $\floor \mu$ is equivalent to $0 \jqas \$y | .[\$y]$.
-The jq filter $\varphi \equiv [3] | .[0] \jqop{=} (\jqf{length}, 2)$
+The jq filter $\varphi \equiv ([3] | .[0] = (\jqf{length}, 2))$
 is lowered to the IR filter
-$\floor \varphi \equiv [3] | (\jqf{length}, 2) \jqas \$z | \floor \mu \update \$z$.
+$\floor \varphi \equiv ([3] | (\jqf{length}, 2) \jqas \$z | \floor \mu \update \$z)$.
 In @sec:semantics, we will see that its output is $\stream{[1], [2]}$.
 :::
 

--- a/syntax.md
+++ b/syntax.md
@@ -197,9 +197,7 @@ Here, $\varphi$ uses the pattern
 $P = [\$x, [\$y], \$z]$ for which
 $\beta P = [\$x, \$y, \$z]$.
 It holds that $\varphi$ is equivalent to
-$$ f \jqas [\$x, [\$y], \$z]
-| [\$x, \$y, \$z] \jqas \$x'
-| \$x' \jqas [\$x, \$y, \$z] | g. $$
+$$ f \jqas [\$x, [\$y], \$z] | [\$x, \$y, \$z] \jqas \$x' | \$x' \jqas [\$x, \$y, \$z] | g. $$
 Here, we first used $\beta P$ as filter
 ($[\$x, \$y, \$z] \jqas \$x' | \dots$) to "serialise" the pattern variables to an array, then as pattern
 ($\$x' \jqas [\$x, \$y, \$z] | \dots$) to "deserialise" the array to retrieve the pattern variables.

--- a/syntax.md
+++ b/syntax.md
@@ -230,7 +230,7 @@ Semantically, we will see that this is equivalent to $(.[]? | .[])$.
 The jq filter $\mu \equiv .[0]$ is lowered to
 $\floor \mu \equiv . \iras \$x | . | (\$x | 0) \iras \$y | .[\$y]$.
 Semantically, we will see that $\floor \mu$ is equivalent to $0 \iras \$y | .[\$y]$.
-The jq filter $\varphi \equiv [3] | .[0] \irop{=} (\irf{length}, 2)$
+The jq filter $\varphi \equiv [3] | .[0] \jqop{=} (\irf{length}, 2)$
 is lowered to the IR filter
 $\floor \varphi \equiv [3] | (\irf{length}, 2) \iras \$z | \floor \mu \update \$z$.
 In @sec:semantics, we will see that its output is $\stream{[1], [2]}$.

--- a/syntax.md
+++ b/syntax.md
@@ -105,10 +105,10 @@ for example, IR does not include "`=`" and "$\arith$`=`".
 @tab:op-correspondence gives an exhaustive list of IR operators and
 their corresponding operators in jq syntax.
 
--- --- --- --------- ------ ----------------- ------ --- ------ --- ------ --- --- -------- ------ ----
-jq `|` `,` `|=`      `//`   `==`              `!=`   `<` `<=`   `>` `>=`   `+` `-` `*`      `/`    `%`
-IR $|$ $,$ $\update$ $\alt$ $\stackrel{?}{=}$ $\neq$ $<$ $\leq$ $>$ $\geq$ $+$ $-$ $\times$ $\div$ $\%$
--- --- --- --------- ------ ----------------- ------ --- ------ --- ------ --- --- -------- ------ ----
+-- --- --- --------- ------ ------- ------ --- ------ --- ------ --- --- -------- ------ ----
+jq `|` `,` `|=`      `//`   `==`    `!=`   `<` `<=`   `>` `>=`   `+` `-` `*`      `/`    `%`
+IR $|$ $,$ $\update$ $\alt$ $\iseq$ $\neq$ $<$ $\leq$ $>$ $\geq$ $+$ $-$ $\times$ $\div$ $\%$
+-- --- --- --------- ------ ------- ------ --- ------ --- ------ --- --- -------- ------ ----
 
 Table: Operators in concrete jq syntax and their corresponding IR operators. {#tab:op-correspondence}
 
@@ -167,8 +167,8 @@ $\floor{f \star g} = \floor f \star \floor g$.
 
 We define filters that yield the boolean values as
 \begin{align*}
-\true  &\coloneq 0    = 0, \\
-\false &\coloneq 0 \neq 0.
+\irf{true}  &\coloneq (0 \iseq 0), \\
+\irf{false} &\coloneq (0  \neq 0).
 \end{align*}
 The filter "$\bool \coloneq \irite{.}{\true}{\false}$"
 maps its input to its boolean value.

--- a/syntax.md
+++ b/syntax.md
@@ -22,7 +22,7 @@ f &\coloneq \quad n \gror s \gror . \gror .. \\
   &\gror f \star f \gror f \cartesian f \\
   &\gror f \jqas P | f \gror \jqfold{reduce}{f}{P}{(f; f)} \gror \jqfold{foreach}{f}{P}{(f; f; f)} \gror \$x \\
   &\gror {\jqlb{label}{x}} | f \gror {\jqlb{break}{x}} \\
-  &\gror {\jqite{f}{f}{f}} \gror \jqkw{try} f \gror \jqkw{try} f \jqkw{catch} f \\
+  &\gror {\jqite{f}{f}{f}} \gror \jqkw{try} f \gror \jqtc{f}{f} \\
   &\gror {\jqdef{x}{f} f} \gror \jqdef{x(x; \dots; x)}{f} f \\
   &\gror x \gror x(f; \dots; f)
 \end{align*}
@@ -88,10 +88,10 @@ An IR filter $f$ is defined by the grammar
 f &\coloneq \quad n \gror s \gror . \\
   &\gror [] \gror [f] \gror {} \gror \{\$x: \$x\} \gror .[p] \\
   &\gror f \star f \gror \$x \cartesian \$x \\
-  &\gror f \iras \$x | f \gror \irfold{reduce}{f}{\$x}{(.; f)} \gror \irfold{foreach}{f}{\$x}{(.; f; f)} \gror \$x \\
-  &\gror {\irite{\$x}{f}{f}} \gror \irtc{f}{f} \\
-  &\gror {\irlb{label}{x}} | f \gror \irlb{break}{x} \\
-  &\gror {\irdef{x(x; \dots; x)}{f} f} \\
+  &\gror f \jqas \$x | f \gror \jqfold{reduce}{f}{\$x}{(.; f)} \gror \jqfold{foreach}{f}{\$x}{(.; f; f)} \gror \$x \\
+  &\gror {\jqite{\$x}{f}{f}} \gror \jqtc{f}{f} \\
+  &\gror {\jqlb{label}{x}} | f \gror \jqlb{break}{x} \\
+  &\gror {\jqdef{x(x; \dots; x)}{f} f} \\
   &\gror x(f; \dots; f)
 \end{align*}
 where $p$ is a path part containing variables instead of filters as indices.
@@ -118,33 +118,33 @@ replace certain occurrences of filters by variables
 | $\varphi$ | $\floor \varphi$ |
 | ----- | ------------ |
 | $n$, $s$, $.$, $\$x$, or $\jqlb{break}{x}$ | $\varphi$ |
-| $..$ | $\irdef{\irf{recurse}}{., (.[]? | \irf{recurse})} \irf{recurse}$ |
+| $..$ | $\jqdef{\jqf{recurse}}{., (.[]? | \jqf{recurse})} \jqf{recurse}$ |
 | $(f)$ | $\floor f$ |
-| $f?$ | $\irlb{label}{x'} | \irtc{\floor f}{(\irlb{break}{x'})}$ |
+| $f?$ | $\jqlb{label}{x'} | \jqtc{\floor f}{(\jqlb{break}{x'})}$ |
 | $[]$ or $\{\}$ | $\varphi$ |
 | $[f]$ | $[\floor f]$ |
-| $\{f: g\}$ | $\floor f \iras \$x' | \floor g \iras \$y' | \{\$x': \$y'\}$ |
+| $\{f: g\}$ | $\floor f \jqas \$x' | \floor g \jqas \$y' | \{\$x': \$y'\}$ |
 | $\{f_1: g_1, \dots, f_n: g_n\}$ | $\floor{\{f_1: g_1\} + \dots + \{f_n: g_n\}}$ |
-| $f [p_1]^? \dots [p_n]^?$ | $. \iras \$x' | \floor f | \floor{[p_1]^?}_{\$x'} | \dots | \floor{[p_n]^?}_{\$x'}$ |
-| $f$ `=` $g$ | $\floor g \iras \$x' | \floor{f \update \$x'}$ |
-| $f$ $\arith$`=` $g$ | $\floor g \iras \$x' | \floor{f \update . \arith \$x'}$ |
+| $f [p_1]^? \dots [p_n]^?$ | $. \jqas \$x' | \floor f | \floor{[p_1]^?}_{\$x'} | \dots | \floor{[p_n]^?}_{\$x'}$ |
+| $f$ `=` $g$ | $\floor g \jqas \$x' | \floor{f \update \$x'}$ |
+| $f$ $\arith$`=` $g$ | $\floor g \jqas \$x' | \floor{f \update . \arith \$x'}$ |
 | $f$ `//=` $g$ | $\floor{f \update . \alt g}$ |
-| $f \jqkw{and} g$ | $\floor{\irite{f}{(g | \irf{bool})}{\text{false}}}$ |
-| $f \jqkw{or}  g$ | $\floor{\irite{f}{\text{true}}{(g | \irf{bool})}}$ |
+| $f \jqkw{and} g$ | $\floor{\jqite{f}{(g | \jqf{bool})}{\text{false}}}$ |
+| $f \jqkw{or}  g$ | $\floor{\jqite{f}{\text{true}}{(g | \jqf{bool})}}$ |
 | $f \star g$ | $\floor f \star \floor g$ |
-| $f \cartesian g$ | $\floor f \iras \$x' | \floor g \iras \$y' | \$x' \cartesian \$y'$ |
-| $f \jqas \$x | g$ | $\floor f \iras \$x | \floor g$ |
-| $f \jqas P | g$ | $\floor f \iras \$x' | \floor{\$x' \iras P | g}$,
-| $\$x \jqas [P_1, \dots, P_n] | g$ | $\floor{\$x \iras \obj{(0): P_1, \dots, (n-1): P_n} | g}$ |
-| $\$x \jqas \obj{f_1: P_1, \dots} | g$ | $\floor{\$x[f_1] \iras \$x' | \$x' \iras P_1 | \$x \iras \obj{f_2: P_2, \dots} | g}$ |
+| $f \cartesian g$ | $\floor f \jqas \$x' | \floor g \jqas \$y' | \$x' \cartesian \$y'$ |
+| $f \jqas \$x | g$ | $\floor f \jqas \$x | \floor g$ |
+| $f \jqas P | g$ | $\floor f \jqas \$x' | \floor{\$x' \jqas P | g}$,
+| $\$x \jqas [P_1, \dots, P_n] | g$ | $\floor{\$x \jqas \obj{(0): P_1, \dots, (n-1): P_n} | g}$ |
+| $\$x \jqas \obj{f_1: P_1, \dots} | g$ | $\floor{\$x[f_1] \jqas \$x' | \$x' \jqas P_1 | \$x \jqas \obj{f_2: P_2, \dots} | g}$ |
 | $\$x \jqas \obj{} | g$ | $\floor g$ |
-| $\jqfold{\fold}{f_x}{\$x}{(f_y; f; g)}$ | $. \iras \$x' | \floor{f_y} | \irfold{\fold}{(\floor{\$x'} | f_x)}{\$x}{(.; \floor f; \floor g)}$ |
-| $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$ | $\floor{\irfold{\fold}{(f_x \iras P | \beta P)}{\$x'}{(f_y; \$x' \iras \beta P | f; \$x' \iras \beta P | g)}}$ |
-| $\jqite{f_x}{f}{g}$ | $\floor{f_x} \iras \$x' | \irite{\$x'}{\floor f}{\floor g}$ |
-| $\jqkw{try} f \jqkw{catch} g$ | $\irlb{label}{x'} | \irtc{\floor f}{(\floor g, \irlb{break}{x'})}$ |
-| $\jqlb{label}{x} | f$ | $\irlb{label}{x} | \floor f$ |
-| $\jqdef{x}{f} g$ | $\irdef{x}{\floor f} \floor g$ |
-| $\jqdef{x(x_1; \dots; x_n)}{f} g$ | $\irdef{x(x_1; \dots; x_n)}{\floor f} \floor g$ |
+| $\jqfold{\fold}{f_x}{\$x}{(f_y; f; g)}$ | $. \jqas \$x' | \floor{f_y} | \jqfold{\fold}{(\floor{\$x'} | f_x)}{\$x}{(.; \floor f; \floor g)}$ |
+| $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$ | $\floor{\jqfold{\fold}{(f_x \jqas P | \beta P)}{\$x'}{(f_y; \$x' \jqas \beta P | f; \$x' \jqas \beta P | g)}}$ |
+| $\jqite{f_x}{f}{g}$ | $\floor{f_x} \jqas \$x' | \jqite{\$x'}{\floor f}{\floor g}$ |
+| $\jqtc{f}{g}$ | $\jqlb{label}{x'} | \jqtc{\floor f}{(\floor g, \jqlb{break}{x'})}$ |
+| $\jqlb{label}{x} | f$ | $\jqlb{label}{x} | \floor f$ |
+| $\jqdef{x}{f} g$ | $\jqdef{x}{\floor f} \floor g$ |
+| $\jqdef{x(x_1; \dots; x_n)}{f} g$ | $\jqdef{x(x_1; \dots; x_n)}{\floor f} \floor g$ |
 | $x(f_1; \dots; f_n)$ | $x(\floor{f_1}; \dots; \floor{f_n})$ |
 
 Table: Lowering of a jq filter $\phi$ to an IR filter $\floor \phi$. {#tab:lowering}
@@ -164,10 +164,10 @@ $\floor{f \star g} = \floor f \star \floor g$.
 
 We define filters that yield the boolean values as
 \begin{align*}
-\irf{true}  &\coloneq (0 \iseq 0), \\
-\irf{false} &\coloneq (0  \neq 0).
+\jqf{true}  &\coloneq (0 \iseq 0), \\
+\jqf{false} &\coloneq (0  \neq 0).
 \end{align*}
-The filter "$\irf{bool} \coloneq (\irite{.}{\true}{\false})$"
+The filter "$\jqf{bool} \coloneq (\jqite{.}{\true}{\false})$"
 maps its input to its boolean value.
 
 In the lowering of the folding operators $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$
@@ -203,10 +203,10 @@ Here, we first used $\beta P$ as filter
 | $[p]  ^?$ | $\floor{[p]^?}_{\$x}$ |
 | --------- | ---------------------- |
 | $[   ]^?$ | $.[]^?$,
-| $[f  ]^?$ | $(\$x | \floor f) \iras \$y' | .[\$y']^?$ |
-| $[f: ]^?$ | $(\$x | \floor f) \iras \$y' | .[\$y':]^?$ |
-| $[ :f]^?$ | $(\$x | \floor f) \iras \$y' | .[:\$y']^?$ |
-| $[f:g]^?$ | $(\$x | \floor f) \iras \$y' | (\$x | \floor g) \iras \$z' | .[\$y':\$z']^?$ |
+| $[f  ]^?$ | $(\$x | \floor f) \jqas \$y' | .[\$y']^?$ |
+| $[f: ]^?$ | $(\$x | \floor f) \jqas \$y' | .[\$y':]^?$ |
+| $[ :f]^?$ | $(\$x | \floor f) \jqas \$y' | .[:\$y']^?$ |
+| $[f:g]^?$ | $(\$x | \floor f) \jqas \$y' | (\$x | \floor g) \jqas \$z' | .[\$y':\$z']^?$ |
 
 Table: Lowering of a path part $[p]^?$ with input $\$x$ to an IR filter. {#tab:lower-path}
 
@@ -222,25 +222,25 @@ all occurrences of superscript "?" in the second column stand for "?", otherwise
 
 ::: {.example}
 The jq filter $(.[]?[])$ is lowered to
-$(. \iras \$x' | . | .[]? | .[])$.
+$(. \jqas \$x' | . | .[]? | .[])$.
 Semantically, we will see that this is equivalent to $(.[]? | .[])$.
 :::
 
 ::: {.example}
 The jq filter $\mu \equiv .[0]$ is lowered to
-$\floor \mu \equiv . \iras \$x | . | (\$x | 0) \iras \$y | .[\$y]$.
-Semantically, we will see that $\floor \mu$ is equivalent to $0 \iras \$y | .[\$y]$.
-The jq filter $\varphi \equiv [3] | .[0] \jqop{=} (\irf{length}, 2)$
+$\floor \mu \equiv . \jqas \$x | . | (\$x | 0) \jqas \$y | .[\$y]$.
+Semantically, we will see that $\floor \mu$ is equivalent to $0 \jqas \$y | .[\$y]$.
+The jq filter $\varphi \equiv [3] | .[0] \jqop{=} (\jqf{length}, 2)$
 is lowered to the IR filter
-$\floor \varphi \equiv [3] | (\irf{length}, 2) \iras \$z | \floor \mu \update \$z$.
+$\floor \varphi \equiv [3] | (\jqf{length}, 2) \jqas \$z | \floor \mu \update \$z$.
 In @sec:semantics, we will see that its output is $\stream{[1], [2]}$.
 :::
 
 The lowering in @tab:lowering is compatible with the semantics of the jq implementation,
 with one notable exception:
 In jq, Cartesian operations $f \cartesian g$ would be lowered to
-$\floor g \iras \$y' | \floor f \iras \$x' | \$x \cartesian \$y$, whereas we lower it to
-$\floor f \iras \$x' | \floor g \iras \$y' | \$x \cartesian \$y$,
+$\floor g \jqas \$y' | \floor f \jqas \$x' | \$x \cartesian \$y$, whereas we lower it to
+$\floor f \jqas \$x' | \floor g \jqas \$y' | \$x \cartesian \$y$,
 thus inverting the binding order.
 Note that the difference only shows when both $f$ and $g$ return multiple values.
 We diverge here from jq to make the lowering of Cartesian operations
@@ -249,7 +249,7 @@ the leftmost filter ($f$) is bound first and the rightmost filter ($g$) is bound
 That also makes it easier to describe other filters, such as
 $\{f_1: g_1, \dots, f_n: g_n\}$, which we can lower to
 $\floor{\{f_1: g_1\} + \dots + \{f_n: g_n\}}$, whereas its lowering assuming the jq lowering of Cartesian operations would be
-$$\floor{\{f_1: g_1\}} \iras \$x'_1 | \dots | \floor{\{f_n: g_n\}} \iras \$x'_n | \$x'_1 + \dots + \$x'_n.$$
+$$\floor{\{f_1: g_1\}} \jqas \$x'_1 | \dots | \floor{\{f_n: g_n\}} \jqas \$x'_n | \$x'_1 + \dots + \$x'_n.$$
 
 ::: {.example}
 The filter $(0, 2) + (0, 1)$ yields
@@ -262,7 +262,7 @@ Informally, we say that a filter is _wellformed_ if all references to
 named filters, variables, and labels were previously bound.
 For example, the filter $a, \$x$ is not wellformed because
 neither $a$ nor $\$x$ was previously bound, but the filter
-$\irdef{a}{1} 2 \iras \$x | a, \$x$ is wellformed.
+$\jqdef{a}{1} 2 \jqas \$x | a, \$x$ is wellformed.
 @tab:wf specifies in detail if a filter is wellformed.
 For this, it uses a context $c = (d, v, l)$, consisting of
 a set $d$ of pairs $(x, n)$ storing the name $x$ and the arity $n$ of a filter,
@@ -275,15 +275,15 @@ $\wf(\varphi, c)$ is true.
 | --------- | ----------------- |
 | $n$, $s$, $.$, $.[p]^?$, $\{\}$ | $\top$ |
 | $\$x$ | $\$x \in v$ |
-| $\irlb{break}{x}$ | $\$x \in l$ |
+| $\jqlb{break}{x}$ | $\$x \in l$ |
 | $[f]$ | $\wf(f, c)$ |
 | $\{\$x: \$y\}$, $\$x \cartesian \$y$ | $\$x \in v$ and $\$y \in v$,
-| $f \star g$, $\irtc{f}{g}$ | $\wf(f, c)$ and $\wf(g, c)$ |
-| $f \iras \$x | g$ | $\wf(f)$ and $\wf(g, (d, v \cup \{\$x\}, l))$ |
-| $\irlb{label}{x} | f$ | $\wf(f, (d, v, l \cup \{\$x\}))$ |
-| $\irite{\$x}{f}{g}$ | $\$x \in v$ and $\wf(f, c)$ and $\wf(g, c)$ |
-| $\irfold{\fold}{f_x}{\$x}{(.; f; g)}$ | $\wf(f_x, c)$ and $\wf((f | g), (d, v \cup \{\$x\}, l))$ |
-| $\irdef{x(x_1; \dots; x_n)}{f} g$ | $\wf(f, (d \cup \bigcup_i \{(x_i, 0)\}, v, l))$ and $\wf(g, (d \cup \{(x, n)\}, v, l))$ |
+| $f \star g$, $\jqtc{f}{g}$ | $\wf(f, c)$ and $\wf(g, c)$ |
+| $f \jqas \$x | g$ | $\wf(f)$ and $\wf(g, (d, v \cup \{\$x\}, l))$ |
+| $\jqlb{label}{x} | f$ | $\wf(f, (d, v, l \cup \{\$x\}))$ |
+| $\jqite{\$x}{f}{g}$ | $\$x \in v$ and $\wf(f, c)$ and $\wf(g, c)$ |
+| $\jqfold{\fold}{f_x}{\$x}{(.; f; g)}$ | $\wf(f_x, c)$ and $\wf((f | g), (d, v \cup \{\$x\}, l))$ |
+| $\jqdef{x(x_1; \dots; x_n)}{f} g$ | $\wf(f, (d \cup \bigcup_i \{(x_i, 0)\}, v, l))$ and $\wf(g, (d \cup \{(x, n)\}, v, l))$ |
 | $x(f_1; \dots; f_n)$ | $(x, n) \in d$ and $\forall i. \wf(f_i, c)$ |
 
 Table: Wellformedness of an IR filter $\varphi$ with respect to a context $c = (d, v, l)$. {#tab:wf}
@@ -292,18 +292,18 @@ For hygienic reasons, we require that labels are disjoint from variables.
 This can be easily ensured by prefixing labels and variables differently.
 
 ::: {.example}
-Consider the filter $\irlb{label}{x} | . \iras \$x | \$x + \$x, \irlb{break}{x}$.
+Consider the filter $\jqlb{label}{x} | . \jqas \$x | \$x + \$x, \jqlb{break}{x}$.
 Here, we have to rename to ensure that labels and variables are disjoint, yielding e.g.
-$\irlb{label}{l_x} | . \iras \$v_x | \$v_x + \$v_x, \irlb{break}{l_x}$.
+$\jqlb{label}{l_x} | . \jqas \$v_x | \$v_x + \$v_x, \jqlb{break}{l_x}$.
 :::
 
 Furthermore, we require that identifiers with the same name represent filters with equal arity.
 This can be ensured by postfixing all identifiers with their arity.
 
 ::: {.example}
-Consider the filter $\irdef{f(g)}{g} \irdef{f}{.} f(f)$.
+Consider the filter $\jqdef{f(g)}{g} \jqdef{f}{.} f(f)$.
 Here, we have to rename identifiers to prevent shadowing issues in the semantics, yielding e.g.
-$\irdef{f^1(g^0)}{g^0} \irdef{f^0}{.} f^1(f^0)$.
+$\jqdef{f^1(g^0)}{g^0} \jqdef{f^0}{.} f^1(f^0)$.
 :::
 
 ::: {.example}
@@ -311,16 +311,16 @@ Consider the jq filter $\jqdef{\jqf{recurse}(f)}{., (f | \jqf{recurse}(f))} \jqf
 which returns the infinite stream of output values $n, n+1, \dots$
 when provided with an input number $n$.
 Lowering this to IR yields
-$\irdef{\irf{recurse}(f)}{., (f | \irf{recurse}(f))} \irf{recurse}(. \iras \$x' | 1 \iras \$y' | \$x' + \$y')$.
+$\jqdef{\jqf{recurse}(f)}{., (f | \jqf{recurse}(f))} \jqf{recurse}(. \jqas \$x' | 1 \jqas \$y' | \$x' + \$y')$.
 :::
 
 ::: {.example}
 Consider the following jq program:
 \begin{align*}
-&\irdef{\irf{empty}}{(\{\}[]) \iras \$x | .} \\
-&\irdef{\irf{select}(f)}{\rsep\irite{f}{.}{\irf{empty}}} \\
-&\irdef{\irf{negative}}{. < 0} \\
-&.[] | \irf{select}(\irf{negative})
+&\jqdef{\jqf{empty}}{(\{\}[]) \jqas \$x | .} \\
+&\jqdef{\jqf{select}(f)}{\rsep\jqite{f}{.}{\jqf{empty}}} \\
+&\jqdef{\jqf{negative}}{. < 0} \\
+&.[] | \jqf{select}(\jqf{negative})
 \end{align*}
 When given an array as an input, it yields
 those elements of the array that are smaller than $0$.^[
@@ -336,10 +336,10 @@ those elements of the array that are smaller than $0$.^[
 ]
 Lowering this to IR yields
 \begin{align*}
-&\irdef{\irf{empty}}{(. \iras \$x' | \{\} | .[]) \iras \$x | .} \\
-&\irdef{\irf{select}(f)}{f \iras \$x' | \irite{\$x'}{.}{\irf{empty}}} \\
-&\irdef{\irf{negative}}{. \iras \$x' | 0 \iras \$y' | \$x' < \$y'} \\
-&. \iras \$x' | . | .[] | \irf{select}(\irf{negative})
+&\jqdef{\jqf{empty}}{(. \jqas \$x' | \{\} | .[]) \jqas \$x | .} \\
+&\jqdef{\jqf{select}(f)}{f \jqas \$x' | \jqite{\$x'}{.}{\jqf{empty}}} \\
+&\jqdef{\jqf{negative}}{. \jqas \$x' | 0 \jqas \$y' | \$x' < \$y'} \\
+&. \jqas \$x' | . | .[] | \jqf{select}(\jqf{negative})
 \end{align*}
 :::
 

--- a/syntax.md
+++ b/syntax.md
@@ -19,34 +19,27 @@ We will now present a subset of jq syntax^[
   semantically equivalent syntax as treated in this text.
 ] of which we have already seen examples in @sec:tour.
 
-\newcommand{\jqkw}[1]{\mathrel{\operatorname{\mathtt{#1}}}}
-\newcommand{\jqas}{\jqkw{as}}
-\newcommand{\jqdef }[3]{\relrel\jqkw{def} #1\!: #2;\; #3}
-\newcommand{\jqite }[3]{\relrel\jqkw{if} #1 \jqkw{then} #2 \jqkw{else} #3 \jqkw{end}}
-\newcommand{\jqfold}[4]{\relrel\jqkw{#1} #2 \jqas #3\; #4}
-\newcommand{\jqlb  }[2]{\relrel\jqkw{#1}\, \$#2}
-
 A _filter_ $f$ is defined by the grammar
 \begin{align*}
 f &\coloneq \quad n \gror s \gror . \gror .. \\
-  &\gror (f) \gror f? \gror [] \gror [f] \gror \{f: f, ..., f: f\} \gror f [p]^? ... [p]^? \\
+  &\gror (f) \gror f? \gror [] \gror [f] \gror \{f: f, \dots, f: f\} \gror f [p]^? \dots [p]^? \\
   &\gror f \star f \gror f \cartesian f \\
   &\gror f \jqas P | f \gror \jqfold{reduce}{f}{P}{(f; f)} \gror \jqfold{foreach}{f}{P}{(f; f; f)} \gror \$x \\
-  &\gror \jqlb{label}{x} | f \gror \jqlb{break}{x} \\
-  &\gror \jqite{f}{f}{f} \gror \jqkw{try} f \gror \jqkw{try} f \jqkw{catch} f \\
-  &\gror \jqdef{x}{f}{f} \gror \jqdef{x(x; ...; x)}{f}{f} \\
-  &\gror x \gror x(f; ...; f)
+  &\gror {\jqlb{label}{x}} | f \gror {\jqlb{break}{x}} \\
+  &\gror {\jqite{f}{f}{f}} \gror \jqkw{try} f \gror \jqkw{try} f \jqkw{catch} f \\
+  &\gror {\jqdef{x}{f}{f}} \gror \jqdef{x(x; \dots; x)}{f}{f} \\
+  &\gror x \gror x(f; \dots; f)
 \end{align*}
 where:
 
 - $p$ is a _path part_ defined by the grammar $p \coloneq \quad \emptyset \gror f \gror f: \gror :f \gror f:f$.
-- $P$ is a _pattern_ defined by the grammar $P \coloneq \quad \$x \gror [P, ..., P] \gror \{f: P, ..., f: P\}$.
+- $P$ is a _pattern_ defined by the grammar $P \coloneq \quad \$x \gror [P, \dots, P] \gror \{f: P, \dots, f: P\}$.
 - $x$ is an identifier (such as `empty`).
 - $n$ is a number (such as `42` or `3.14`).
 - $s$ is a string (such as `"Hello world!"`).
 
 We use the superscript "$?$" to denote an optional presence of "?"; in particular,
-$f [p]^?... [p]^?$ can be
+$f [p]^? \dots [p]^?$ can be
 $f [p]$, $f [p]?$,
 $f [p] [p]$, $f [p]? [p]$, $f [p] [p]?$, $f [p]? [p]?$,
 $f [p] [p] [p]$, and so on.
@@ -96,14 +89,14 @@ in a much less verbose way than for actual jq syntax.
 
 An IR filter $f$ is defined by the grammar
 \begin{align*}
-f \coloneq& \quad n \gror s \gror . \\
-  \gror& [] \gror [f] \gror {} \gror \{\$x: \$x\} \gror .[p] \\
-  \gror& f \star f \gror \$x \cartesian \$x \\
-  \gror& f \as \$x | f \gror \reduce f \as \$x (.; f) \gror \foreac f \as \$x (.; f; f) \gror \$x \\
-  \gror& \ite{\$x}{f}{f} \gror \try f \catch f \\
-  \gror& \labelx x | f \gror \breakx x \\
-  \gror& {\deff x(x; ...; x): f; f} \\
-  \gror& x(f; ...; f)
+f &\coloneq \quad n \gror s \gror . \\
+  &\gror [] \gror [f] \gror {} \gror \{\$x: \$x\} \gror .[p] \\
+  &\gror f \star f \gror \$x \cartesian \$x \\
+  &\gror f \iras \$x | f \gror \irfold{reduce}{f}{\$x}{(.; f)} \gror \irfold{foreach}{f}{\$x}{(.; f; f)} \gror \$x \\
+  &\gror {\irite{\$x}{f}{f}} \gror \irtc{f}{f} \\
+  &\gror {\irlb{label}{x}} | f \gror \irlb{break}{x} \\
+  &\gror {\irdef{x(x; \dots; x)}{f}{f}} \\
+  &\gror x(f; \dots; f)
 \end{align*}
 where $p$ is a path part containing variables instead of filters as indices.
 
@@ -121,41 +114,41 @@ Table: Operators in concrete jq syntax and their corresponding IR operators. {#t
 
 Compared to actual jq syntax, IR filters
 have significantly simpler path operations
-($.[p]$ versus $f [p]^?... [p]^?$) and
+($.[p]$ versus $f [p]^? \dots [p]^?$) and
 replace certain occurrences of filters by variables
 (e.g. $\$x \cartesian \$x$ versus $f \cartesian f$).
 
 | $\varphi$ | $\floor \varphi$ |
 | ----- | ------------ |
 | $n$, $s$, $.$, $\$x$, or $\jqlb{break}{x}$ | $\varphi$ |
-| $..$ | $\deff \recurse: ., (.[]? | \recurse); \recurse$ |
+| $..$ | $\irdef{\irf{recurse}}{., (.[]? | \irf{recurse})}{\irf{recurse}}$ |
 | $(f)$ | $\floor f$ |
-| $f?$ | $\labelx{x'} | \try \floor f \catch (\breakx{x'})$ |
+| $f?$ | $\irlb{label}{x'} | \irtc{\floor f}{(\irlb{break}{x'})}$ |
 | $[]$ or $\{\}$ | $\varphi$ |
 | $[f]$ | $[\floor f]$ |
-| $\{f: g\}$ | $\floor f \as \$x' | \floor g \as \$y' | \{\$x': \$y'\}$ |
-| $\{f_1: g_1, \dots, f_n: g_n\}$ | $\floor{\{f_1: g_1\} + ... + \{f_n: g_n\}}$ |
-| $f [p_1]^? \dots [p_n]^?$ | $. \as \$x' | \floor f | \floor{[p_1]^?}_{\$x'} | ... | \floor{[p_n]^?}_{\$x'}$ |
-| $f$ `=` $g$ | $\floor g \as \$x' | \floor{f \update \$x'}$ |
-| $f$ $\arith$`=` $g$ | $\floor g \as \$x' | \floor{f \update . \arith \$x'}$ |
+| $\{f: g\}$ | $\floor f \iras \$x' | \floor g \iras \$y' | \{\$x': \$y'\}$ |
+| $\{f_1: g_1, \dots, f_n: g_n\}$ | $\floor{\{f_1: g_1\} + \dots + \{f_n: g_n\}}$ |
+| $f [p_1]^? \dots [p_n]^?$ | $. \iras \$x' | \floor f | \floor{[p_1]^?}_{\$x'} | \dots | \floor{[p_n]^?}_{\$x'}$ |
+| $f$ `=` $g$ | $\floor g \iras \$x' | \floor{f \update \$x'}$ |
+| $f$ $\arith$`=` $g$ | $\floor g \iras \$x' | \floor{f \update . \arith \$x'}$ |
 | $f$ `//=` $g$ | $\floor{f \update . \alt g}$ |
-| $f \jqkw{and} g$ | $\floor{\ite{f}{(g | \bool)}{\text{false}}}$ |
-| $f \jqkw{or}  g$ | $\floor{\ite{f}{\text{true}}{(g | \bool)}}$ |
+| $f \jqkw{and} g$ | $\floor{\irite{f}{(g | \bool)}{\text{false}}}$ |
+| $f \jqkw{or}  g$ | $\floor{\irite{f}{\text{true}}{(g | \bool)}}$ |
 | $f \star g$ | $\floor f \star \floor g$ |
-| $f \cartesian g$ | $\floor f \as \$x' | \floor g \as \$y' | \$x' \cartesian \$y'$ |
-| $f \jqas \$x | g$ | $\floor f \as \$x | \floor g$ |
-| $f \jqas P | g$ | $\floor f \as \$x' | \floor{\$x' \as P | g}$,
-| $\$x \jqas [P_1, ..., P_n] | g$ | $\floor{\$x \as {(0): P_1, ..., (n-1): P_n} | g}$ |
-| $\$x \jqas {f_1: P_1, ...} | g$ | $\floor{.[\$x | f_1] \as \$x' | \$x' \as P_1 | \$x \as {f_2: P_2, ...} | g}$ |
-| $\$x \jqas \{\} | g$ | $\floor g$ |
-| $\jqfold{\fold}{f_x}{\$x}{(f_y; f; g)}$ | $. \as \$x' | \floor{f_y} | \fold \floor{\$x'} | f_x) \as \$x (.; \floor f; \floor g)$ |
-| $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$ | $\floor{\fold (f_x \as P | \beta P) \as \$x' (f_y; \$x' \as \beta P | f; \$x' \as \beta P | g)}$ |
-| $\jqite{f_x}{f}{g}$ | $\floor{f_x} \as \$x' | \ite{\$x'}{\floor f}{\floor g}$ |
-| $\jqkw{try} f \jqkw{catch} g$ | $\labelx{x'} | \try \floor f \catch {\floor g, \breakx{x'}}$ |
-| $\jqlb{label}{x} | f$ | $\labelx x | \floor f$ |
-| $\jqdef{x}{f}{g}$ | $\deff x: \floor f; \floor g$ |
-| $\jqdef{x(x_1; ...; x_n)}{f}{g}$ | $\deff x(x_1; ...; x_n): \floor f; \floor g$ |
-| $x(f_1; ...; f_n)$ | $x(\floor{f_1}; ...; \floor{f_n})$ |
+| $f \cartesian g$ | $\floor f \iras \$x' | \floor g \iras \$y' | \$x' \cartesian \$y'$ |
+| $f \jqas \$x | g$ | $\floor f \iras \$x | \floor g$ |
+| $f \jqas P | g$ | $\floor f \iras \$x' | \floor{\$x' \iras P | g}$,
+| $\$x \jqas [P_1, \dots, P_n] | g$ | $\floor{\$x \iras \obj{(0): P_1, \dots, (n-1): P_n} | g}$ |
+| $\$x \jqas \obj{f_1: P_1, \dots} | g$ | $\floor{\$x[f_1] \iras \$x' | \$x' \iras P_1 | \$x \iras \obj{f_2: P_2, \dots} | g}$ |
+| $\$x \jqas \obj{} | g$ | $\floor g$ |
+| $\jqfold{\fold}{f_x}{\$x}{(f_y; f; g)}$ | $. \iras \$x' | \floor{f_y} | \fold \floor{\$x'} | f_x) \iras \$x (.; \floor f; \floor g)$ |
+| $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$ | $\floor{\fold (f_x \iras P | \beta P) \iras \$x' (f_y; \$x' \iras \beta P | f; \$x' \iras \beta P | g)}$ |
+| $\jqite{f_x}{f}{g}$ | $\floor{f_x} \iras \$x' | \irite{\$x'}{\floor f}{\floor g}$ |
+| $\jqkw{try} f \jqkw{catch} g$ | $\irlb{label}{x'} | \irtc{\floor f}{(\floor g, \irlb{break}{x'})}$ |
+| $\jqlb{label}{x} | f$ | $\irlb{label}{x} | \floor f$ |
+| $\jqdef{x}{f}{g}$ | $\irdef{x}{\floor f}{\floor g}$ |
+| $\jqdef{x(x_1; \dots; x_n)}{f}{g}$ | $\irdef{x(x_1; \dots; x_n)}{\floor f}{\floor g}$ |
+| $x(f_1; \dots; f_n)$ | $x(\floor{f_1}; \dots; \floor{f_n})$ |
 
 Table: Lowering of a jq filter $\phi$ to an IR filter $\floor \phi$. {#tab:lowering}
 
@@ -189,7 +182,7 @@ We define filters that yield the boolean values as
 \true  &\coloneq 0    = 0, \\
 \false &\coloneq 0 \neq 0.
 \end{align*}
-The filter "$\bool \coloneq \ite{.}{\true}{\false}$"
+The filter "$\bool \coloneq \irite{.}{\true}{\false}$"
 maps its input to its boolean value.
 
 In the lowering of the folding operators $\jqfold{\fold}{f_x}{P}{(f_y; f; g)}$
@@ -198,45 +191,45 @@ we replace the pattern $P$ by a variable by
 "serialising" and "deserialising" the variables bound by $P$ with $\beta P$.
 Here, $\beta P$ denotes the sequence of variables bound by $P$:
 $$\beta P = \begin{cases}
-  \sum_i \beta P_i & \text{if $P = [P_1, ..., P_n]$ or $P = \{f_1: P_1, \dots, f_n: P_n\}$} \\
+  \sum_i \beta P_i & \text{if $P = [P_1, \dots, P_n]$ or $P = \{f_1: P_1, \dots, f_n: P_n\}$} \\
   [\$x] & \text{if $P = \$x$}
 \end{cases}$$
-(We used $\sum_i x_i = x_1 + ... + x_n$ and $[x_1, ..., x_n] + [y_1, ..., y_m] = [x_1, ..., x_n, y_1, ..., y_m]$.)
+(We used $\sum_i x_i = x_1 + \dots + x_n$ and $[x_1, \dots, x_n] + [y_1, \dots, y_m] = [x_1, \dots, x_n, y_1, \dots, y_m]$.)
 In particular, we exploit the property that
 $f \jqas P | g$ can be rewritten to
 $$ f \jqas P | \beta P \jqas \$x' | \$x' \jqas \beta P | g, $$
 because $\beta P$ can be interpreted both as pattern and as filter.
 
 ::: {.example}
-  Consider the filter $\varphi \equiv f \jqas [\$x, [\$y], \$z] | g$.
-  This filter destructures all outputs of $f$ that are of the shape
-  $[x, [y, ...], z, ...]$ and binds the values
-  $x$, $y$, and $z$ to the respective variables.
-  Here, $\varphi$ uses the pattern
-  $P = [\$x, [\$y], \$z]$ for which
-  $\beta P = [\$x, \$y, \$z]$.
-  It holds that $\varphi$ is equivalent to
-  $$ f \jqas [\$x, [\$y], \$z]
-  | [\$x, \$y, \$z] \jqas \$x'
-  | \$x' \jqas [\$x, \$y, \$z] | g. $$
-  Here, we first used $\beta P$ as filter
-  ($[\$x, \$y, \$z] \jqas \$x' | ...$) to "serialise" the pattern variables to an array, then as pattern
-  ($\$x' \jqas [\$x, \$y, \$z] | ...$) to "deserialise" the array to retrieve the pattern variables.
+Consider the filter $\varphi \equiv f \jqas [\$x, [\$y], \$z] | g$.
+This filter destructures all outputs of $f$ that are of the shape
+$[x, [y, \dots], z, \dots]$ and binds the values
+$x$, $y$, and $z$ to the respective variables.
+Here, $\varphi$ uses the pattern
+$P = [\$x, [\$y], \$z]$ for which
+$\beta P = [\$x, \$y, \$z]$.
+It holds that $\varphi$ is equivalent to
+$$ f \jqas [\$x, [\$y], \$z]
+| [\$x, \$y, \$z] \jqas \$x'
+| \$x' \jqas [\$x, \$y, \$z] | g. $$
+Here, we first used $\beta P$ as filter
+($[\$x, \$y, \$z] \jqas \$x' | \dots$) to "serialise" the pattern variables to an array, then as pattern
+($\$x' \jqas [\$x, \$y, \$z] | \dots$) to "deserialise" the array to retrieve the pattern variables.
 :::
 
 | $[p]  ^?$ | $\floor{[p]^?}_{\$x}$ |
 | --------- | ---------------------- |
 | $[   ]^?$ | $.[]^?$,
-| $[f  ]^?$ | $(\$x | \floor f) \as \$y' | .[\$y']^?$ |
-| $[f: ]^?$ | $(\$x | \floor f) \as \$y' | .[\$y':]^?$ |
-| $[ :f]^?$ | $(\$x | \floor f) \as \$y' | .[:\$y']^?$ |
-| $[f:g]^?$ | $(\$x | \floor f) \as \$y' | (\$x | \floor g) \as \$z' | .[\$y':\$z']^?$ |
+| $[f  ]^?$ | $(\$x | \floor f) \iras \$y' | .[\$y']^?$ |
+| $[f: ]^?$ | $(\$x | \floor f) \iras \$y' | .[\$y':]^?$ |
+| $[ :f]^?$ | $(\$x | \floor f) \iras \$y' | .[:\$y']^?$ |
+| $[f:g]^?$ | $(\$x | \floor f) \iras \$y' | (\$x | \floor g) \iras \$z' | .[\$y':\$z']^?$ |
 
 Table: Lowering of a path part $[p]^?$ with input $\$x$ to an IR filter. {#tab:lower-path}
 
 @tab:lower-path shows how to lower a path part $p^?$ to IR filters.
 Like in @sec:hir, the meaning of superscript "$?$" is an optional presence of "$?$".
-In the lowering of $f [p_1]^? ... [p_n]^?$ in @tab:lowering,
+In the lowering of $f [p_1]^? \dots [p_n]^?$ in @tab:lowering,
 if $[p_i]$ in the first column is directly followed by "?", then
 $\floor{[p_i]^?}_{\$x}$ in the second column stands for
 $\floor{[p_i] ?}_{\$x}$, otherwise for
@@ -245,47 +238,48 @@ Similarly, in @tab:lower-path, if $[p]$ in the first column is followed by "$?$"
 all occurrences of superscript "?" in the second column stand for "?", otherwise for nothing.
 
 ::: {.example}
-  The jq filter `(.[]?[])` is lowered to
-  $(. \as \$x' | . | .[]? | .[])$.
-  Semantically, we will see that this is equivalent to $(.[]? | .[])$.
+The jq filter `(.[]?[])` is lowered to
+$(. \iras \$x' | . | .[]? | .[])$.
+Semantically, we will see that this is equivalent to $(.[]? | .[])$.
 :::
 
 ::: {.example}
-  The jq filter $\mu \equiv$ `.[0]` is lowered to
-  $\floor \mu \equiv . \as \$x | . | (\$x | 0) \as \$y | .[\$y]$.
-  Semantically, we will see that $\floor \mu$ is equivalent to $0 \as \$y | .[\$y]$.
-  The jq filter $\varphi \equiv$ `[3] | .[0] = (length, 2)`
-  is lowered to the IR filter
-  $\floor \varphi \equiv [3] | (\length, 2) \as \$z | \floor \mu \update \$z$.
-  In @sec:semantics, we will see that its output is $\stream{[1], [2]}$.
+The jq filter $\mu \equiv$ `.[0]` is lowered to
+$\floor \mu \equiv . \iras \$x | . | (\$x | 0) \iras \$y | .[\$y]$.
+Semantically, we will see that $\floor \mu$ is equivalent to $0 \iras \$y | .[\$y]$.
+The jq filter $\varphi \equiv$ `[3] | .[0] = (length, 2)`
+is lowered to the IR filter
+$\floor \varphi \equiv [3] | (\length, 2) \iras \$z | \floor \mu \update \$z$.
+In @sec:semantics, we will see that its output is $\stream{[1], [2]}$.
 :::
 
 The lowering in @tab:lowering is compatible with the semantics of the jq implementation,
 with one notable exception:
 In jq, Cartesian operations $f \cartesian g$ would be lowered to
-$\floor g \as \$y' | \floor f \as \$x' | \$x \cartesian \$y$, whereas we lower it to
-$\floor f \as \$x' | \floor g \as \$y' | \$x \cartesian \$y$,
+$\floor g \iras \$y' | \floor f \iras \$x' | \$x \cartesian \$y$, whereas we lower it to
+$\floor f \iras \$x' | \floor g \iras \$y' | \$x \cartesian \$y$,
 thus inverting the binding order.
 Note that the difference only shows when both $f$ and $g$ return multiple values.
 We diverge here from jq to make the lowering of Cartesian operations
 consistent with that of other operators, such as $\{f: g\}$, where
 the leftmost filter ($f$) is bound first and the rightmost filter ($g$) is bound last.
 That also makes it easier to describe other filters, such as
-$\{f_1: g_1, ..., f_n: g_n\}$, which we can lower to
-$\floor{\{f_1: g_1\} + ... + \{f_n: g_n\}}$, whereas its lowering assuming the jq lowering of Cartesian operations would be
-$$\floor{\{f_1: g_1\}} \as \$x'_1 | ... | \floor{\{f_n: g_n\}} \as \$x'_n | \$x'_1 + ... + \$x'_n.$$
+$\{f_1: g_1, \dots, f_n: g_n\}$, which we can lower to
+$\floor{\{f_1: g_1\} + \dots + \{f_n: g_n\}}$, whereas its lowering assuming the jq lowering of Cartesian operations would be
+$$\floor{\{f_1: g_1\}} \iras \$x'_1 | \dots | \floor{\{f_n: g_n\}} \iras \$x'_n | \$x'_1 + \dots + \$x'_n.$$
 
 ::: {.example}
-  The filter $(0, 2) + (0, 1)$ yields
-  $\stream{0, 1, 2, 3}$ using our lowering, and
-  $\stream{0, 2, 1, 3}$ in jq.
+The filter $(0, 2) + (0, 1)$ yields
+$\stream{0, 1, 2, 3}$ using our lowering, and
+$\stream{0, 2, 1, 3}$ in jq.
 :::
 
+\newcommand{\wf}{\operatorname{wf}}
 Informally, we say that a filter is _wellformed_ if all references to
 named filters, variables, and labels were previously bound.
 For example, the filter $a, \$x$ is not wellformed because
 neither $a$ nor $\$x$ was previously bound, but the filter
-$\deff a: 1; 2 \as \$x | a, \$x$ is wellformed.
+$\deff a: 1; 2 \iras \$x | a, \$x$ is wellformed.
 @tab:wf specifies in detail if a filter is wellformed.
 For this, it uses a context $c = (d, v, l)$, consisting of
 a set $d$ of pairs $(x, n)$ storing the name $x$ and the arity $n$ of a filter,
@@ -298,16 +292,16 @@ $\wf(\varphi, c)$ is true.
 | --------- | ----------------- |
 | $n$, $s$, $.$, $.[p]^?$, $\{\}$ | $\top$ |
 | $\$x$ | $\$x \in v$ |
-| $\breakx x$ | $\$x \in l$ |
+| $\irlb{break}{x}$ | $\$x \in l$ |
 | $[f]$ | $\wf(f, c)$ |
-| $\{\$x: \$y\}$, $\$x \cartesian \$y$ | $\$x \in v \andop \$y \in v$,
-| $f \star g$, $\try f \catch g$ | $\wf(f, c) \andop \wf(g, c)$ |
-| $f \as \$x | g$ | $\wf(f) \andop \wf(g, (d, v \cup \{\$x\}, l))$ |
-| $\labelx x | f$ | $\wf(f, (d, v, l \cup \{\$x\}))$ |
-| $\ite{\$x}{f}{g}$ | $\$x \in v \andop \wf(f, c) \andop \wf(g, c)$ |
-| $\fold f_x \as \$x (.; f; g)$ | $\wf(f_x, c) \andop \wf((f | g), (d, v \cup \{\$x\}, l))$ |
-| $\deff x(x_1; \dots; x_n): f; g$ | $\wf(f, (d \cup \bigcup_i \{(x_i, 0)\}, v, l)) \andop \wf(g, (d \cup \{(x, n)\}, v, l))$ |
-| $x(f_1; ...; f_n)$ | $(x, n) \in d \andop \forall i. \wf(f_i, c)$ |
+| $\{\$x: \$y\}$, $\$x \cartesian \$y$ | $\$x \in v$ and $\$y \in v$,
+| $f \star g$, $\irtc{f}{g}$ | $\wf(f, c)$ and $\wf(g, c)$ |
+| $f \iras \$x | g$ | $\wf(f)$ and $\wf(g, (d, v \cup \{\$x\}, l))$ |
+| $\irlb{label}{x} | f$ | $\wf(f, (d, v, l \cup \{\$x\}))$ |
+| $\irite{\$x}{f}{g}$ | $\$x \in v$ and $\wf(f, c)$ and $\wf(g, c)$ |
+| $\irfold{\fold}{f_x}{\$x}{(.; f; g)}$ | $\wf(f_x, c)$ and $\wf((f | g), (d, v \cup \{\$x\}, l))$ |
+| $\irdef{x(x_1; \dots; x_n)}{f}{g}$ | $\wf(f, (d \cup \bigcup_i \{(x_i, 0)\}, v, l))$ and $\wf(g, (d \cup \{(x, n)\}, v, l))$ |
+| $x(f_1; \dots; f_n)$ | $(x, n) \in d$ and $\forall i. \wf(f_i, c)$ |
 
 Table: Wellformedness of an IR filter $\varphi$ with respect to a context $c = (d, v, l)$. {#tab:wf}
 
@@ -315,47 +309,47 @@ For hygienic reasons, we require that labels are disjoint from variables.
 This can be easily ensured by prefixing labels and variables differently.
 
 ::: {.example}
-  Consider the filter $\labelx x | . \as \$x | \$x + \$x, \breakx x$.
-  Here, we have to rename to ensure that labels and variables are disjoint, yielding e.g.
-  $\labelx{l_x} | . \as \$v_x | \$v_x + \$v_x, \breakx{l_x}$.
+Consider the filter $\irlb{label}{x} | . \iras \$x | \$x + \$x, \irlb{break}{x}$.
+Here, we have to rename to ensure that labels and variables are disjoint, yielding e.g.
+$\irlb{label}{l_x} | . \iras \$v_x | \$v_x + \$v_x, \irlb{break}{l_x}$.
 :::
 
 Furthermore, we require that identifiers with the same name represent filters with equal arity.
 This can be ensured by postfixing all identifiers with their arity.
 
 ::: {.example}
-  Consider the filter $\deff f(g): g; \deff f: .; f(f)$.
-  Here, we have to rename identifiers to prevent shadowing issues in the semantics, yielding e.g.
-  $\deff f^1(g^0): g^0; \deff f^0: .; f^1(f^0)$.
+Consider the filter $\irdef{f(g)}{g}{\irdef{f}{.}{f(f)}}$.
+Here, we have to rename identifiers to prevent shadowing issues in the semantics, yielding e.g.
+$\irdef{f^1(g^0)}{g^0}{\irdef{f^0}{.}{f^1(f^0)}}$.
 :::
 
 ::: {.example}
-  Consider the jq program `def recurse(f): ., (f | recurse(f)); recurse(. + 1)`,
-  which returns the infinite stream of output values $n, n+1, \dots$
-  when provided with an input number $n$.
-  Lowering this to IR yields
-  $\deff \recurse(f): ., (f | \recurse(f)); \recurse(. \as \$x' | 1 \as \$y' | \$x' + \$y').$
+Consider the jq program `def recurse(f): ., (f | recurse(f)); recurse(. + 1)`,
+which returns the infinite stream of output values $n, n+1, \dots$
+when provided with an input number $n$.
+Lowering this to IR yields
+$\irdef{\irf{recurse}(f)}{., (f | \irf{recurse}(f))}{\irf{recurse}(. \iras \$x' | 1 \iras \$y' | \$x' + \$y')}$.
 :::
 
 ::: {.example}
-  Consider the following jq program:
+Consider the following jq program:
 
-  ```
-  def empty: {}[] as $x | .
-  def select(f): if f then . else empty end;
-  def negative: . < 0;
-  .[] | select(negative)
-  ```
+```
+def empty: {}[] as $x | .
+def select(f): if f then . else empty end;
+def negative: . < 0;
+.[] | select(negative)
+```
 
-  When given an array as an input, it yields
-  those elements of the array that are smaller than $0$.
-  Lowering this to IR yields
-  \begin{align*}
-  &\deff \emptyf: (\{\}[] | .[]) \as \$x | .; \\
-  &\deff \operatorname{select}(f): f \as \$x' | \ite{\$x'}{.}{\emptyf}; \\
-  &\deff \operatorname{negative}: . \as \$x' | 0 \as \$y' | \$x' < \$y'; \\
-  &.[] | \operatorname{select}(\operatorname{negative})
-  \end{align*}
+When given an array as an input, it yields
+those elements of the array that are smaller than $0$.
+Lowering this to IR yields
+\begin{align*}
+&\deff \irf{empty}: (\{\}[] | .[]) \iras \$x | .; \\
+&\deff \irf{select}(f): f \iras \$x' | \irite{\$x'}{.}{\irf{empty}}; \\
+&\deff \irf{negative}: . \iras \$x' | 0 \iras \$y' | \$x' < \$y'; \\
+&.[] | \irf{select}(\irf{negative})
+\end{align*}
 :::
 
 @sec:semantics shows how to run an IR filter $f$.

--- a/values.md
+++ b/values.md
@@ -11,8 +11,8 @@ Furthermore, we assume that $\valt$ can be encoded in lambda calculus.
 
 We encode boolean values as follows:
 \begin{align*}
-\true : \boolt &\coloneq \lambda t\, f. t \\
-\false: \boolt &\coloneq \lambda t\, f. f
+\true : \boolt &\coloneqq \lambda t\, f. t \\
+\false: \boolt &\coloneqq \lambda t\, f. f
 \end{align*}
 
 We assume the existence of functions
@@ -25,16 +25,16 @@ We use natural numbers to store label identifiers.
 The elements returned by our filters are _value results_ $\resultt$, which are
 either OK or an exception (an error or a break).
 \begin{align*}
-\ok    &: \valt \to \resultt \coloneq \lambda x\, o\, e\, b. o\, x \\
-\err   &: \valt \to \resultt \coloneq \lambda x\, o\, e\, b. e\, x \\
-\breakf&: \mathbb N \to \resultt \coloneq \lambda x\, o\, e\, b. b\, x
+\ok    &: \valt \to \resultt \coloneqq \lambda x\, o\, e\, b. o\, x \\
+\err   &: \valt \to \resultt \coloneqq \lambda x\, o\, e\, b. e\, x \\
+\breakf&: \mathbb N \to \resultt \coloneqq \lambda x\, o\, e\, b. b\, x
 \end{align*}
 
 We will use _lists_ $\listt$ of value results as return type of filters.
 Because the jq language is evaluated lazily, lists can be infinite.
 \begin{alignat*}{3}
-\cons&: \resultt \to \listt \to{} &&\listt \coloneq \lambda h\, t. && \lambda c\, n. c\, h\, t \\
-\nil&:                                  &&\listt \coloneq                && \lambda c\, n. n
+\cons&: \resultt \to \listt \to{} &&\listt \coloneqq \lambda h\, t. && \lambda c\, n. c\, h\, t \\
+\nil&:                                  &&\listt \coloneqq                && \lambda c\, n. n
 \end{alignat*}
 
 We write the empty list
@@ -52,7 +52,7 @@ Y_n: & ((T_1 \to ... \to T_n &&\to U) \to T_1 \to ... \to T_n &&\to U) \to T_1 \
 \end{alignat*}
 
 We define the concatenation of two lists $l$ and $r$ as
-$$l + r \coloneq Y_1\, (\lambda f\, l. l\, (\lambda h\, t. \cons\, h\, (f\, t))\, r)\, l,$$
+$$l + r \coloneqq Y_1\, (\lambda f\, l. l\, (\lambda h\, t. \cons\, h\, (f\, t))\, r)\, l,$$
 which satisfies the equational property
 $$l + r = l\, (\lambda h\, t. \cons\, h\, (t + r))\, r.$$
 For simplicity, we will define recursive functions from here on mostly by equational properties,
@@ -66,9 +66,9 @@ $l \bindl f$ applies $f$ to all elements of $l$ and concatenates the outputs.
 For a list $l$ and a function $f$ from a _value_ to a list,
 $l \bind f$ applies OK values in $l$ to $f$ and returns exception values in $l$.
 \begin{alignat*}{7}
-&\bindr&&: \resultt &&\to (\valt &&\to \resultt&&) &&\to \resultt &&\coloneq \lambda r\, f. r\, (\lambda o. f\, o)\, (\lambda e. r)\, (\lambda b. r) \\
-&\bindl&&: \listt &&\to (\resultt &&\to \listt&&) &&\to \listt &&\coloneq \lambda l\, f. l\, (\lambda h\, t. f\, h + (t \bindl f))\, \nil \\
-&\bind &&: \listt &&\to (\valt &&\to \listt&&) &&\to \listt &&\coloneq \lambda l\, f. l \bindl (\lambda x. x\, (\lambda o. f\, o)\, (\lambda e. \stream x)\, (\lambda b. \stream x))
+&\bindr&&: \resultt &&\to (\valt &&\to \resultt&&) &&\to \resultt &&\coloneqq \lambda r\, f. r\, (\lambda o. f\, o)\, (\lambda e. r)\, (\lambda b. r) \\
+&\bindl&&: \listt &&\to (\resultt &&\to \listt&&) &&\to \listt &&\coloneqq \lambda l\, f. l\, (\lambda h\, t. f\, h + (t \bindl f))\, \nil \\
+&\bind &&: \listt &&\to (\valt &&\to \listt&&) &&\to \listt &&\coloneqq \lambda l\, f. l \bindl (\lambda x. x\, (\lambda o. f\, o)\, (\lambda e. \stream x)\, (\lambda b. \stream x))
 \end{alignat*}
 
 
@@ -116,8 +116,8 @@ that transforms a list into a value result:
 It returns an array if all list elements are values, or into
 the first exception in the list otherwise:
 \begin{alignat*}{2}
-\sumf&: \listt \to \valt &&\to \resultt \coloneq \lambda l\, n. l\, (\lambda h\, t. h \bindr (\lambda o. (n + o \bindr \sumf\, t)))\, (\ok(n)) \\
-\arr &: \listt           &&\to \resultt \coloneq \lambda l. \sumf\, (l \bind (\lambda v. \stream{\ok((\arr_1\, v))}))\, \arr_0
+\sumf&: \listt \to \valt &&\to \resultt \coloneqq \lambda l\, n. l\, (\lambda h\, t. h \bindr (\lambda o. (n + o \bindr \sumf\, t)))\, (\ok(n)) \\
+\arr &: \listt           &&\to \resultt \coloneqq \lambda l. \sumf\, (l \bind (\lambda v. \stream{\ok((\arr_1\, v))}))\, \arr_0
 \end{alignat*}
 Here, the function $\sumf$ takes a list $l$ and a zero value $n$ and
 returns the sum of the zero value and the list elements if they are all OK,

--- a/values.md
+++ b/values.md
@@ -95,8 +95,8 @@ That means that every arithmetic operation can fail.
 Definitions of the arithmetic operators for JSON values are given in @sec:arithmetic.
 
 The value type must also provide Boolean operations
-$\{<, \leq, >, \geq, \stackrel{?}{=}, \neq\}$, where
-$l \stackrel{?}{=} r$ returns whether $l$ equals $r$, and
+$\{<, \leq, >, \geq, \iseq, \neq\}$, where
+$l \iseq r$ returns whether $l$ equals $r$, and
 $l \neq r$ returns its negation.
 Each of these Boolean operations is of type $\valt \to \valt \to \valt$.
 The order on JSON values is defined in @sec:json-order.

--- a/values.md
+++ b/values.md
@@ -27,7 +27,7 @@ either OK or an exception (an error or a break).
 \begin{align*}
 \ok    &: \valt \to \resultt \coloneq \lambda x\, o\, e\, b. o\, x \\
 \err   &: \valt \to \resultt \coloneq \lambda x\, o\, e\, b. e\, x \\
-\breakf&:  \mathbb N \to \resultt \coloneq \lambda x\, o\, e\, b. b\, x
+\breakf&: \mathbb N \to \resultt \coloneq \lambda x\, o\, e\, b. b\, x
 \end{align*}
 
 We will use _lists_ $\listt$ of value results as return type of filters.


### PR DESCRIPTION
Before this PR, we had three different syntaxes: concrete jq syntax, HIR, and MIR.
Now, there is only concrete jq syntax and IR (previously MIR), and IR is now a strict subset of concrete jq syntax.
This makes it much easier to distinguish the syntactic part (in typewriter font) from the semantic part (in normal font).

Furthermore, this PR enables HTML output.

Apart from this, this PR features a series of small corrections throughout the document.